### PR TITLE
Change package name so godoc generates docs

### DIFF
--- a/for/readme.md
+++ b/for/readme.md
@@ -9,7 +9,7 @@ There's nothing new so far, so try and write it yourself for practice.
 ## Write the test first
 
 ```go
-package main
+package iteration
 
 import "testing"
 
@@ -34,7 +34,7 @@ _Keep the discipline!_ You don't need to know anything new right now to make the
 All you need to do right now is enough to make it compile so you can check your test is written well.
 
 ```go
-package main
+package iteration
 
 func Repeat(character string) string  {
 	return ""

--- a/for/v1/repeat.go
+++ b/for/v1/repeat.go
@@ -1,4 +1,4 @@
-package main
+package iteration
 
 func Repeat(character string) string {
 	var repeated string

--- a/for/v1/repeat_test.go
+++ b/for/v1/repeat_test.go
@@ -1,4 +1,4 @@
-package main
+package iteration
 
 import "testing"
 

--- a/for/v2/repeat.go
+++ b/for/v2/repeat.go
@@ -1,4 +1,4 @@
-package main
+package iteration
 
 const repeatCount = 5
 

--- a/for/v2/repeat_test.go
+++ b/for/v2/repeat_test.go
@@ -1,4 +1,4 @@
-package main
+package iteration
 
 import "testing"
 

--- a/for/vx/repeat.go
+++ b/for/vx/repeat.go
@@ -1,4 +1,4 @@
-package main
+package iteration
 
 const repeatCount = 5
 

--- a/for/vx/repeat_test.go
+++ b/for/vx/repeat_test.go
@@ -1,4 +1,4 @@
-package main
+package iteration
 
 import "testing"
 

--- a/integers/readme.md
+++ b/integers/readme.md
@@ -5,7 +5,7 @@ Integers work as you would expect. Let's write an add function to try things out
 ## Write the test first
 
 ```go
-package main
+package integers
 
 import "testing"
 
@@ -34,6 +34,8 @@ Inspect the compilation error
 Write enough code to satisfy the compiler *and that's all* - remember we want to check that our tests fail for the correct reason.
 
 ```go
+package integers
+
 func Add(x, y int) int {
 	return 0
 }

--- a/integers/v1/adder.go
+++ b/integers/v1/adder.go
@@ -1,4 +1,4 @@
-package main
+package integers
 
 func Add(x, y int) int {
 	return x + y

--- a/integers/v1/adder_test.go
+++ b/integers/v1/adder_test.go
@@ -1,4 +1,4 @@
-package main
+package integers
 
 import "testing"
 

--- a/integers/v2/adder.go
+++ b/integers/v2/adder.go
@@ -1,4 +1,4 @@
-package main
+package integers
 
 // Add takes two integers and returns the sum of them
 func Add(x, y int) int {

--- a/integers/v2/adder_test.go
+++ b/integers/v2/adder_test.go
@@ -1,4 +1,4 @@
-package main
+package integers
 
 import (
 	"fmt"


### PR DESCRIPTION
`godoc` does not show any docs for files stored in `package main`. I've renamed the packages to how far I've gotten through this course, to match the chapters.

The docs will be generated with this change.