### PR TITLE
Note added for exampe integer function

### DIFF
--- a/integers.md
+++ b/integers.md
@@ -126,6 +126,8 @@ $ go test -v
 --- PASS: ExampleAdd (0.00s)
 ```
 
+Please note that the example function will not be executed if you remove the comment "//Output: 6".Although the function will be compiled, it won't be executed.
+
 By adding this code in the example will appear in the documentation inside `godoc` making your code even more accessible.
 
 ## Wrapping up


### PR DESCRIPTION
Note added mentioning that the presence of comment is important for execution of the example function.