### PR TITLE
add markdown lint, tidy doc style

### DIFF
--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,18 @@
+git_recurse true
+
+rules "MD001", "MD002", "MD003", "MD004", "MD005", "MD006", "MD007", "MD008", "MD009", "MD011", "MD012", "MD014", "MD015", "MD016", "MD017", "MD018", "MD019", "MD020", "MD021", "MD023", "MD025", "MD028", "MD030", "MD035", "MD037", "MD038", "MD040", "MD041", "MD042"
+
+# exclude rules
+exclude "MD010" # Hard tabs
+exclude "MD013" # Line length
+exclude "MD022" # Headers should be surrounded by blank lines
+exclude "MD024" # Multiple headers with the same content
+exclude "MD026" # Trailing punctuation in header
+exclude "MD027" # Multiple spaces after blockquote symbol
+exclude "MD029" # Ordered list item prefix
+exclude "MD031" # Fenced code blocks should be surrounded by blank lines
+exclude "MD032" # Lists should be surrounded by blank lines
+exclude "MD033" # Inline HTML
+exclude "MD034" # Bare URL used
+exclude "MD036" # Emphasis used instead of a header
+exclude "MD039" # Spaces inside link text

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,17 @@ go:
 
 install: true
 
-before_script:
-  - go get -u golang.org/x/lint/golint
+stages:
+  - build
+  - markdownlint
 
-script:
-  - ./build.sh
+jobs:
+  include:
+    - stage: build
+      script:
+        - go get -u golang.org/x/lint/golint
+        - ./build.sh
+    - stage: markdownlint
+      script:
+        - gem install mdl
+        - mdl .

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,4 +1,3 @@
-
 # Table of contents
 
 * [Learn Go with tests](gb-readme.md)
@@ -19,11 +18,11 @@
 
 ## Standard lib essentials
 
-- [HTTP server](http-server.md)
-- JSON (todo)
-- `io` (todo)
-- `time` (todo)
-- Sorting (todo
+* [HTTP server](http-server.md)
+* JSON (todo)
+* `io` (todo)
+* `time` (todo)
+* Sorting (todo
 
 ## Meta
 

--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -6,7 +6,7 @@ Arrays allow you to store multiple elements of the same type in a variable in
 a particular order.
 
 When you have an array, it is very common to have to iterate over them. So let's
-use [our new-found knowledge of `for`][for] to make a `Sum` function. `Sum` will
+use [our new-found knowledge of `for`](for.md) to make a `Sum` function. `Sum` will
 take an array of numbers and return the total.
 
 Let's use our TDD skills
@@ -75,7 +75,7 @@ To get the value out of an array at a particular index, just use `array[index]`
 syntax. In this case we are using `for` to iterate 5 times to work through the
 array and add each item onto `sum`.
 
-#### A note on source control
+### A note on source control
 
 At this point if you are using source control \(which you should!\) I would
 `commit` the code as it is. We have working software backed by a test.
@@ -102,7 +102,7 @@ func Sum(numbers [5]int) int {
 values, the index and the value. We are choosing to ignore the index value by
 using `_` [blank identifier](https://golang.org/doc/effective_go.html#blank).
 
-#### Back to source control
+### Back to source control
 
 Now we are happy with the code I would amend the previous commit so we only
 check in the lovely version of our code with its test.

--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
     "structure": {
-        "readme": "gb-readme.md" 
+        "readme": "gb-readme.md"
     }
 }

--- a/concurrency.md
+++ b/concurrency.md
@@ -78,7 +78,7 @@ The function is in production and being used to check hundreds of websites. But
 your colleague has started to get complaints that it's slow, so they've asked
 you to help speed it up.
 
-### Write a test
+## Write a test
 
 Let's use a benchmark to test the speed of `CheckWebsites` so that we can see the
 effect of our changes.
@@ -523,11 +523,7 @@ have been performed because
 > [Premature optimization is the root of all evil][popt]
 > -- Donald Knuth
 
-[Arrays]: ../arrays-and-slices.md#
-[For]: ../iteration.md#
 [DI]: ../dependency-injection.md#
 [wrf]: http://wiki.c2.com/?MakeItWorkMakeItRightMakeItFast
-[godoc_maps]: https://blog.golang.org/go-maps-in-action
-[godoc_zero_values]: https://golang.org/ref/spec#The_zero_value
 [godoc_race_detector]: https://blog.golang.org/race-detector
 [popt]: http://wiki.c2.com/?PrematureOptimization

--- a/contributing.md
+++ b/contributing.md
@@ -1,29 +1,28 @@
 # Contributing
 
-Contributions are very welcome, I hope for this to become a great home for guides of how to learn go by writing tests
+Contributions are very welcome, I hope for this to become a great home for guides of how to learn go by writing tests.
 
 ## What we're looking for
 
-* Teaching Go features \(e.g things like `if`, `select`, structs, methods, etc\)
+* Teaching Go features \(e.g things like `if`, `select`, structs, methods, etc\).
 * Showcase interesting functionality within the standard library. Show off how easy it is to TDD a HTTP server for instance.
-* Show how Go's tooling, like benchmarking, race detectors, etc can help you arrive at great software
+* Show how Go's tooling, like benchmarking, race detectors, etc can help you arrive at great software.
 
 If you don't feel confident to submit your own guide, submitting an issue for something you want to learn is still a valuable contribution.
 
 ## Style guide
 
-* Always be reinforcing the TDD cycle. Take a look at [template.md]()
+* Always be reinforcing the TDD cycle. Take a look at [template.md]().
 * Emphasis on iterating over functionality driven by tests. The Hello, world example works well because we gradually make it more sophisticated and learning new techniques _driven_ by the tests. For example:
   * `Hello()` &lt;- how to write functions, return types.
-  * `Hello(name string)` &lt;- arguments, constants
-  * `Hello(name string)` &lt;- default to "world" using `if`
-  * `Hello(name, language string)` &lt;- `switch`
+  * `Hello(name string)` &lt;- arguments, constants.
+  * `Hello(name string)` &lt;- default to "world" using `if`.
+  * `Hello(name, language string)` &lt;- `switch`.
 * Try and minimise the surface area of required knowledge.
-  * Thinking of examples that showcase what you're trying to teach without confusing the reader with other features is important. 
+  * Thinking of examples that showcase what you're trying to teach without confusing the reader with other features is important.
   * For example you can learn about `struct`s without understanding pointers.
   * Brevity is king.
 * Follow the [Code Review Comments style guide](https://github.com/golang/go/wiki/CodeReviewComments). It's important for a consistent style across all the sections.
-* Your section should have a runnable application at the end \(e.g `package main` with a `main` func\) so users can see it in action and play with it
-* All tests should pass
-* Run `./build.sh` before raising PR
-
+* Your section should have a runnable application at the end \(e.g `package main` with a `main` func\) so users can see it in action and play with it.
+* All tests should pass.
+* Run `./build.sh` before raising PR.

--- a/dependency-injection.md
+++ b/dependency-injection.md
@@ -6,10 +6,10 @@ It is assumed that you have read the structs section before as some understandin
 
 There is _a lot_ of misunderstandings around dependency injection around the programming community. Hopefully this guide will show you how
 
-* You dont need a framework
+* You don't need a framework
 * It does not overcomplicate your design
 * It facilitates testing
-* It allows you to write great, general-purpose functions. 
+* It allows you to write great, general-purpose functions.
 
 We want to write a function that greets someone, just like we did in the hello-world chapter but this time we are going to be testing the _actual printing_.
 
@@ -118,7 +118,7 @@ func Greet(writer *bytes.Buffer, name string) {
 }
 ```
 
-The test now passes
+The test now passes.
 
 ## Refactor
 
@@ -186,9 +186,9 @@ func main() {
 }
 ```
 
-Go to [http://localhost:5000](http://localhost:5000). You'll see your greeting function being used.
+Run the program and go to [http://localhost:5000](http://localhost:5000). You'll see your greeting function being used.
 
-HTTP servers will be covered in a later chapter so dont worry too much about the details.
+HTTP servers will be covered in a later chapter so don't worry too much about the details.
 
 When you write a HTTP handler, you are given a `http.ResponseWriter` and the `http.Request` that was used to make the request. When you implement your server you _write_ your response using the writer.
 
@@ -200,7 +200,7 @@ Our first round of code was not easy to test because it wrote data to somewhere 
 
 _Motivated by our tests_ we refactored the code so we could control _where_ the data was written by **injecting a dependency** which allowed us to:
 
-* **Test our code** If you cant test a function _easily_, it's usually because of dependencies hard-wired into a function _or_ global state. If you have a global database connection pool for instance that is used by some kind of service layer, it is likely going to be difficult to test and they will be slow to run. DI will motivate you to inject in a database dependency \(via an interface\) which you can then mock out with something you can control in your tests.
+* **Test our code** If you can't test a function _easily_, it's usually because of dependencies hard-wired into a function _or_ global state. If you have a global database connection pool for instance that is used by some kind of service layer, it is likely going to be difficult to test and they will be slow to run. DI will motivate you to inject in a database dependency \(via an interface\) which you can then mock out with something you can control in your tests.
 * **Separate our concerns**, decoupling _where the data goes_ from _how to generate it_. If you ever feel like a method/function has too many responsibilities \(generating data _and_ writing to a db? handling HTTP requests _and_ doing domain level logic?\) DI is probably going to be the tool you need.
 * **Allow our code to be re-used in different contexts** The first "new" context our code can be used in is inside tests. But further on if someone wants to try something new with your function they can inject their own dependencies.
 
@@ -215,4 +215,3 @@ By having some familiarity of the `io.Writer` interface we are able to use `byte
 The more familiar you are with the standard library the more you'll see these general purpose interfaces which you can then re-use in your own code to make your software reusable in a number of contexts.
 
 This example is heavily influenced from a chapter in [The Go Programming language](https://www.amazon.co.uk/Programming-Language-Addison-Wesley-Professional-Computing/dp/0134190440), so if you enjoyed this, go buy it!
-

--- a/gb-readme.md
+++ b/gb-readme.md
@@ -64,4 +64,3 @@ Taking my experience of learning with a group and my own personal way I am going
 * Add issues or [tweet me @quii](https://twitter.com/quii)
 
 [MIT license](https://github.com/quii/learn-go-with-tests/tree/842f4f24d1f1c20ba3bb23cbc376c7ca6f7ca79a/LICENSE.md)
-

--- a/hello-world.md
+++ b/hello-world.md
@@ -81,7 +81,7 @@ If statements in Go are very much like other programming languages.
 
 **Declaring variables**
 
-We're declaring some variables with the syntax `varName := value`, which lets us re-use some values in our test for readability
+We're declaring some variables with the syntax `varName := value`, which lets us re-use some values in our test for readability.
 
 **t.Errorf**
 
@@ -99,7 +99,7 @@ The vast majority of the standard library has excellent documentation with examp
 
 Now that we have a test we can iterate on our software safely.
 
-In the last example we wrote the test _after_ the code had been written just so you could get an example of how to write a test and declare a function. From this point on we will be _writing tests first_
+In the last example we wrote the test _after_ the code had been written just so you could get an example of how to write a test and declare a function. From this point on we will be _writing tests first_.
 
 Our next requirement is to let us specify the recipient of the greeting.
 
@@ -166,7 +166,7 @@ func Hello(name string) string {
 
 When you run the tests they should now pass. Normally as part of the TDD cycle we should now _refactor_.
 
-There's not a lot to refactor here, but we can introduce another language feature _constants_
+There's not a lot to refactor here, but we can introduce another language feature _constants_.
 
 ### Constants
 
@@ -194,7 +194,7 @@ To be clear, the performance boost is incredibly negligible for this example! Bu
 
 ## Hello, world... again
 
-The next requirement is when our function is called with an empty string it defaults to printing "Hello, World", rather than "Hello, "
+The next requirement is when our function is called with an empty string it defaults to printing "Hello, World", rather than "Hello, ".
 
 Start by writing a new failing test
 
@@ -278,7 +278,7 @@ func Hello(name string) string {
 }
 ```
 
-If we run our tests we should see it satisfies the new requirement and we haven't accidentally broken the other functionality
+If we run our tests we should see it satisfies the new requirement and we haven't accidentally broken the other functionality.
 
 ### Discipline
 
@@ -466,17 +466,17 @@ func greetingPrefix(language string) (prefix string) {
 
 A few new concepts:
 
-* In our function signature we have made a _named return value_ `(prefix string)`. 
-* This will create a variable called `prefix` in your function
-  * It will be assigned the "zero" value. This depends on the type, for example `int`s are 0 and for strings it is `""` 
-    * You can return whatever it's set to by just calling `return` rather than `return prefix`. 
+* In our function signature we have made a _named return value_ `(prefix string)`.
+* This will create a variable called `prefix` in your function.
+  * It will be assigned the "zero" value. This depends on the type, for example `int`s are 0 and for strings it is `""`.
+    * You can return whatever it's set to by just calling `return` rather than `return prefix`.
   * This will display in the Go Doc for your function so it can make the intent of your code clearer.
-* `default` in the switch case will be branched to if none of the other `case` statements match
+* `default` in the switch case will be branched to if none of the other `case` statements match.
 * The function name starts with a lowercase letter. In Go public functions start with a capital letter and private ones start with a lowercase. We don't want the internals of our algorithm to be exposes to the world so we made this function private.
 
 ## Wrapping up
 
-Who knew you could get so much out of `Hello, world` ?
+Who knew you could get so much out of `Hello, world`?
 
 By now you should have some understanding of:
 
@@ -493,7 +493,6 @@ By now you should have some understanding of:
 * Writing the smallest amount of code to make it pass so we know we have working software
 * _Then_ refactor, backed with the safety of our tests to ensure we have well-crafted code that is easy to work with
 
-  In our case we've gone from `Hello()` to `Hello("name")`, to `Hello("name", "french")` in small, easy to understand steps.
+In our case we've gone from `Hello()` to `Hello("name")`, to `Hello("name", "french")` in small, easy to understand steps.
 
-  This is of course trivial compared to "real world" software but the principles still stand. TDD is a skill that needs practice to develop but by being able to break problems down into smaller components that you can test you will have a much easier time writing software.
-
+This is of course trivial compared to "real world" software but the principles still stand. TDD is a skill that needs practice to develop but by being able to break problems down into smaller components that you can test you will have a much easier time writing software.

--- a/http-server.md
+++ b/http-server.md
@@ -5,7 +5,7 @@
 You have been asked to create a web server where users can track how many games players have won
 
 - `GET /players/{name}` should return a number indicating total number of wins
-- `POST /players/{name}` should record a win for that name, incrementing for every subsequent `POST` 
+- `POST /players/{name}` should record a win for that name, incrementing for every subsequent `POST`
 
 We will follow the TDD approach, getting working software as quickly as we can and then making small iterative improvements until we have the solution. By taking this approach we
 
@@ -19,31 +19,31 @@ Throughout this book we have emphasised the TDD process of write a test & watch 
 
 This discipline of writing the minimal amount of code is important in terms of the safety TDD gives you. You should be striving to get out of "red" as soon as you can.
 
-Kent Beck describes it as 
+Kent Beck describes it as:
 
 > Make the test work quickly, committing whatever sins necessary in process.
 
 You can commit these sins because you will refactor afterwards backed by the safety of the tests.
 
-#### What if you don't do this?
+### What if you don't do this?
 
-The more changes you make while in red, the more likely you are to add more problems, not covered by tests. 
+The more changes you make while in red, the more likely you are to add more problems, not covered by tests.
 
 The idea is to be iteratively writing useful code with small steps, driven by tests so that you don't fall into a rabbit hole for hours.
 
 ### Chicken and egg
 
-How can we incrementally build this? We cant `GET` a player without having stored something and it seems hard to know if `POST` has worked without the `GET` endpoint already existing. 
+How can we incrementally build this? We cant `GET` a player without having stored something and it seems hard to know if `POST` has worked without the `GET` endpoint already existing.
 
-This is where _mocking_ shines. 
+This is where _mocking_ shines.
 
 - `GET` will need a `PlayerStore` _thing_ to get scores for a player. This should be an interface so when we test we can create a simple stub to test our code without needing to have implemented any actual storage code.
 - For `POST` we can _spy_ on its calls to `PlayerStore` to make sure it stores players correctly. Our implementation of saving wont be coupled to retrieval.
-- For having some working software quickly we can make a very simple in-memory implementation and then later we can create an implementation backed by whatever storage mechanism we prefer. 
+- For having some working software quickly we can make a very simple in-memory implementation and then later we can create an implementation backed by whatever storage mechanism we prefer.
 
 ## Write the test first
 
-We can write a test and make it pass by returning a hard-coded value to get us started. Kent Beck refers this as "Faking it". Once we have a working test we can then write more tests to help us remove that constant
+We can write a test and make it pass by returning a hard-coded value to get us started. Kent Beck refers this as "Faking it". Once we have a working test we can then write more tests to help us remove that constant.
 
 By doing this very small step, we can make the important start of getting an overall project structure working correctly without having to worry too much about our application logic.
 
@@ -81,7 +81,7 @@ t.Run("returns Pepper's score", func(t *testing.T) {
 })
 ```
 
-In order to test our server, we will need a `Request` to send in and we'll want to _spy_ on what our handler writes to the `ResponseWriter`. 
+In order to test our server, we will need a `Request` to send in and we'll want to _spy_ on what our handler writes to the `ResponseWriter`.
 
 - We use `http.NewRequest` to create a request. The first argument is the request's method and the second is the request's path. The `nil` argument refers to the request's body, which we don't need to set in this case.
 - `net/http/httptest` has a spy already made for us called `ResponseRecorder` so we can use that. It has many helpful methods to inspect what has been written as a response.
@@ -163,9 +163,9 @@ func main() {
 }
 ```
 
-So far all of our application code has been in one file, however this isn't best practice for larger projects where you'll want to separate things into different files. 
+So far all of our application code has been in one file, however this isn't best practice for larger projects where you'll want to separate things into different files.
 
-To run this, do `go build` which will take all the `.go` files in the directory and build you a program. You can then execute it with `./myprogram`. 
+To run this, do `go build` which will take all the `.go` files in the directory and build you a program. You can then execute it with `./myprogram`.
 
 ### `http.HandlerFunc`
 
@@ -173,14 +173,13 @@ Earlier we explored that the `Handler` interface is what we need to implement in
 
 [HandlerFunc](https://golang.org/pkg/net/http/#HandlerFunc) lets us avoid this.
 
-> The HandlerFunc type is an adapter to allow the use of ordinary functions as HTTP handlers. If f is a function with the appropriate signature, HandlerFunc(f) is a Handler that calls f. 
+> The HandlerFunc type is an adapter to allow the use of ordinary functions as HTTP handlers. If f is a function with the appropriate signature, HandlerFunc(f) is a Handler that calls f.
 
 ```go
 type HandlerFunc func(ResponseWriter, *Request)
 ```
 
 So we use this to wrap our `PlayerServer` function so that it now conforms to `Handler`.
-
 
 ### `http.ListenAndServe(":5000"...`
 
@@ -212,7 +211,7 @@ You may have been thinking
 
 > Surely we need some kind of concept of storage to control which player gets what score. It's weird that the values seem so arbitrary in our tests.
 
-Remember we are just trying to take as small as steps as reasonably possible, so we're just trying to break the constant for now. 
+Remember we are just trying to take as small as steps as reasonably possible, so we're just trying to break the constant for now.
 
 ## Try to run the test
 ```
@@ -243,7 +242,7 @@ func PlayerServer(w http.ResponseWriter, r *http.Request) {
 
 This test has forced us to actually look at the request's URL and make a decision. So whilst in our heads we may have been worrying about player stores and interfaces the next logical step actually seems to be about _routing_.
 
-If we did started with the store code the amount of changes we'd have to do would be very large compared to this. **This is a smaller step towards our final goal and was driven by tests**
+If we did started with the store code the amount of changes we'd have to do would be very large compared to this. **This is a smaller step towards our final goal and was driven by tests**.
 
 We're resisting the temptation to use any routing libraries right now, just the smallest step to get our test passing.
 
@@ -309,11 +308,11 @@ func assertResponseBody(t *testing.T, got, want string) {
 }
 ```
 
-However we still shouldn't be happy. It doesn't feel right that our server knows the scores. 
+However we still shouldn't be happy. It doesn't feel right that our server knows the scores.
 
-Our refactoring has made it pretty clear what to do. 
+Our refactoring has made it pretty clear what to do.
 
-We moved the score calculation out of the main body of our handler into a function `GetPlayerScore`. This feels like the right place to separate the concerns using interfaces. 
+We moved the score calculation out of the main body of our handler into a function `GetPlayerScore`. This feels like the right place to separate the concerns using interfaces.
 
 Let's move our function we re-factored to be an interface instead
 
@@ -359,7 +358,7 @@ func (p *PlayerServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
-#### Fix the issues
+### Fix the issues
 
 This was quite a few changes and we know our tests and application will no longer compile but just relax and let the compiler work through it
 
@@ -370,7 +369,7 @@ We need to change our tests to instead create a new instance of our `PlayerServe
 ```go
 func TestGETPlayers(t *testing.T) {
 	server := &PlayerServer{}
-	
+
 	t.Run("returns the Pepper's score", func(t *testing.T) {
 		request := newGetScoreRequest("Pepper")
 		response := httptest.NewRecorder()
@@ -391,9 +390,9 @@ func TestGETPlayers(t *testing.T) {
 }
 ```
 
-Notice we're still not worrying about making stores _just yet_, we just want the compiler passing as soon as we can. 
+Notice we're still not worrying about making stores _just yet_, we just want the compiler passing as soon as we can.
 
-You should be in the habit of prioritising having code that compiles and then code that passes the tests. 
+You should be in the habit of prioritising having code that compiles and then code that passes the tests.
 
 By adding more functionality (like stub stores) whilst the code isn't compiling we are opening ourselves up to potentially _more_ compilation problems.
 
@@ -417,7 +416,7 @@ panic: runtime error: invalid memory address or nil pointer dereference [recover
 	panic: runtime error: invalid memory address or nil pointer dereference
 ```
 
-This is because we have not passed in a `PlayerStore` in our tests. We'll need to make a stub one up. 
+This is because we have not passed in a `PlayerStore` in our tests. We'll need to make a stub one up.
 
 ```go
 type StubPlayerStore struct {
@@ -464,13 +463,13 @@ func TestGETPlayers(t *testing.T) {
 
 Our tests now pass and are looking better. The _intent_ behind our code is clearer now due to the introduction of the store. We're telling the reader that because we have _this data in a `PlayerStore`_ that when you use it with a `PlayerServer` you should get the following responses.
 
-#### Run the application
+### Run the application
 
-Now our tests are passing the last thing we need to do to complete this refactor is to check our application is working. The program should start up but you'll get a horrible response if you try and hit the server at `http://localhost:5000/players/Pepper`. 
+Now our tests are passing the last thing we need to do to complete this refactor is to check our application is working. The program should start up but you'll get a horrible response if you try and hit the server at `http://localhost:5000/players/Pepper`.
 
 The reason for this is that we have not passed in a `PlayerStore`.
 
-We'll need to make an implementation of one, but that's difficult right now as we're not storing any meaningful data so it'll have to be hard-coded for the time being. 
+We'll need to make an implementation of one, but that's difficult right now as we're not storing any meaningful data so it'll have to be hard-coded for the time being.
 
 ```go
 type InMemoryPlayerStore struct{}
@@ -488,7 +487,7 @@ func main() {
 }
 ```
 
-If you `go build` again and hit the same URL you should get `"123"`. Not great, but until we store data that's the best we can do. 
+If you `go build` again and hit the same URL you should get `"123"`. Not great, but until we store data that's the best we can do.
 
 We have a few options as to what to do next
 
@@ -531,20 +530,20 @@ t.Run("returns 404 on missing players", func(t *testing.T) {
 ```go
 func (p *PlayerServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	player := r.URL.Path[len("/players/"):]
-	
+
 	w.WriteHeader(http.StatusNotFound)
-	
+
 	fmt.Fprint(w, p.store.GetPlayerScore(player))
 }
 ```
 
-Sometimes I heavily roll my eyes when TDD advocates say "make sure you just write the minimal amount of code to make it pass" as it can feel very pedantic. 
+Sometimes I heavily roll my eyes when TDD advocates say "make sure you just write the minimal amount of code to make it pass" as it can feel very pedantic.
 
-But this scenario illustrates the example well. I have done the bare minimum (knowing it is not correct), which is write a `StatusNotFound` on **all responses** but all our tests are passing! 
+But this scenario illustrates the example well. I have done the bare minimum (knowing it is not correct), which is write a `StatusNotFound` on **all responses** but all our tests are passing!
 
 **By doing the bare minimum to make the tests pass it can highlight gaps in your tests** In our case we are not asserting that we should be getting a `StatusOK` when players _do_ exist in the store.
 
-Update the other two tests to assert on the status and fix the code. 
+Update the other two tests to assert on the status and fix the code.
 
 Here are the new tests
 
@@ -593,7 +592,7 @@ func assertStatus(t *testing.T, got, want int) {
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
 	}
-} 
+}
 
 func newGetScoreRequest(name string) *http.Request {
 	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/players/%s", name), nil)
@@ -608,14 +607,14 @@ func assertResponseBody(t *testing.T, got, want string) {
 }
 ```
 
-We're checking the status in all our tests now so I made a helper `assertStatus` to facilitate that. 
+We're checking the status in all our tests now so I made a helper `assertStatus` to facilitate that.
 
 Now our first two tests fail because of the 404 instead of 200 so we can fix `PlayerServer` to only return not found if the score is 0.
 
 ```go
 func (p *PlayerServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	player := r.URL.Path[len("/players/"):]
-	
+
 	score := p.store.GetPlayerScore(player)
 
 	if score == 0 {
@@ -650,8 +649,7 @@ func TestStoreWins(t *testing.T) {
 }
 ```
 
-For a start let's just check we get the correct status code if we hit the particular route with POST. This lets us drive out the functionality of accepting a different kind of request and handling it differently to `GET /player/{name}`. Once this works we can then start asserting on our handler's interaction with the store
-
+For a start let's just check we get the correct status code if we hit the particular route with POST. This lets us drive out the functionality of accepting a different kind of request and handling it differently to `GET /player/{name}`. Once this works we can then start asserting on our handler's interaction with the store.
 
 ## Try to run the test
 
@@ -660,9 +658,10 @@ For a start let's just check we get the correct status code if we hit the partic
     --- FAIL: TestStoreWins/it_returns_accepted_on_POST (0.00s)
     	server_test.go:70: did not get correct status, got 404, want 202
 ```
+
 ## Write enough code to make it pass
 
-Remember we are deliberately committing sins, so an if statement based on the request's method will do the trick. 
+Remember we are deliberately committing sins, so an if statement based on the request's method will do the trick.
 
 ```go
 func (p *PlayerServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -795,7 +794,7 @@ store := StubPlayerStore{
 ```
 ## Write enough code to make it pass
 
-As we're only asserting the number of calls rather than the specific values it makes our initial iteration a little smaller. 
+As we're only asserting the number of calls rather than the specific values it makes our initial iteration a little smaller.
 
 We need to update `PlayerServer`'s idea of what a `PlayerStore` is by changing the interface if we're going to be able to call `RecordWin`
 
@@ -813,7 +812,7 @@ By doing this `main` no longer compiles
 	*InMemoryPlayerStore does not implement PlayerStore (missing RecordWin method)
 ```
 
-The compiler tells us what's wrong. Let's update `InMemoryPlayerStore` to have that method. 
+The compiler tells us what's wrong. Let's update `InMemoryPlayerStore` to have that method.
 
 ```go
 type InMemoryPlayerStore struct{}
@@ -821,7 +820,7 @@ type InMemoryPlayerStore struct{}
 func (i *InMemoryPlayerStore) RecordWin(name string) {}
 ```
 
-Try and run the tests and we should be back to compiling code but the test still failing. 
+Try and run the tests and we should be back to compiling code but the test still failing.
 
 Now that `PlayerStore` has `RecordWin` we can call it within our `PlayerServer`
 
@@ -925,7 +924,7 @@ Integration tests can be useful for testing that larger areas of your system wor
 - When they fail, it can be difficult to know why (as usually its a bug within a component of the integration test) and can be harder to fix
 - Sometimes slower to run (as they often are used to test against a "real" component, like a database)
 
-For that reason, it is recommended that you research _The Test Pyramid_
+For that reason, it is recommended that you research _The Test Pyramid_.
 
 ## Write the test first
 
@@ -936,7 +935,7 @@ func TestRecordingWinsAndRetrievingThem(t *testing.T) {
 	store := InMemoryPlayerStore{}
 	server := PlayerServer{&store}
 	player := "Pepper"
-	
+
 	server.ServeHTTP(httptest.NewRecorder(), newPostWinRequest(player))
 	server.ServeHTTP(httptest.NewRecorder(), newPostWinRequest(player))
 	server.ServeHTTP(httptest.NewRecorder(), newPostWinRequest(player))
@@ -951,7 +950,7 @@ func TestRecordingWinsAndRetrievingThem(t *testing.T) {
 
 - We are creating our two components we are trying to integrate with; `InMemoryPlayerStore` and `PlayerServer`.
 - We then fire off 3 requests to record 3 wins for `player`. We're not too concerned about the status codes in this test as it's not relevant to whether they are integrating well.
-- The next response we do care about (so we store a variable `response`) because we are going to try and get the `player`'s score. 
+- The next response we do care about (so we store a variable `response`) because we are going to try and get the `player`'s score.
 
 ## Try to run the test
 
@@ -962,9 +961,9 @@ func TestRecordingWinsAndRetrievingThem(t *testing.T) {
 
 ## Write enough code to make it pass
 
-I am going to take some liberties here and write more code than you may be comfortable with without writing a test. 
+I am going to take some liberties here and write more code than you may be comfortable with without writing a test.
 
-_This is allowed_! We still have a test checking things should be working correctly but it is not around the specific unit we're working with (`InMemoryPlayerStore`)
+_This is allowed_! We still have a test checking things should be working correctly but it is not around the specific unit we're working with (`InMemoryPlayerStore`).
 
 If i were to get stuck in this scenario, I would revert my changes back to the failing test and then write more specific unit tests around `InMemoryPlayerStore` to help me drive out a solution.
 
@@ -1014,7 +1013,7 @@ Build it, run it and then use CURL to test it out
 - Run this a few times, change the player names if you like `curl -X POST http://localhost:5000/players/Pepper`
 - Check scores with `curl http://localhost:5000/players/Pepper`
 
-Great! You've made a REST-ish service. To take this forward you'd want to pick a data store so you can persist the scores longer than the length of time the program runs. 
+Great! You've made a REST-ish service. To take this forward you'd want to pick a data store so you can persist the scores longer than the length of time the program runs.
 
 - Pick a store (Bolt? Mongo? Postgres? File system?)
 - Make `PostgresPlayerStore` implement `PlayerStore`
@@ -1034,11 +1033,11 @@ Great! You've made a REST-ish service. To take this forward you'd want to pick a
 
 - Let's you iteratively build the system up in smaller chunks
 - Allows you to develop a handler that needs a storage without needing actual storage
-- TDD to drive out the interfaces you need 
+- TDD to drive out the interfaces you need
 
 ### Commit sins, then refactor (and then commit to source control)
 
 - You need to treat having failing compilation or failing tests as a red situation that you need to get out of as soon as you can
-- Write just the necessary code to get there. _Then_ refactor and make the code nice. 
+- Write just the necessary code to get there. _Then_ refactor and make the code nice.
 - By trying to do too many changes whilst the code isn't compiling or the tests are failing puts you at risk of compounding the problems
-- Sticking to this approach forces you to write small tests, which means small changes which helps keeps working on complex systems manageable 
+- Sticking to this approach forces you to write small tests, which means small changes which helps keeps working on complex systems manageable

--- a/install-go.md
+++ b/install-go.md
@@ -87,14 +87,14 @@ brew cask install visual-studio-code
 You can confirm vs code installed correctly you can run the following in your shell.
 
 ```sh
-code . 
+code .
 ```
 
 vs code is shipped with very little software enabled, you enable new software by installing extensions.  To add Go support you must install a extension, there are a variety available for vs code, an exceptional one is [Luke Hobans package](https://github.com/Microsoft/vscode-go).  This can be installed as follows:
 
 ```sh
 code --install-extension lukehoban.Go
-``` 
+```
 
 When you open a Go file for the first time in vs code, it will indicate that the Analysis tools are missing, you should click the button to install these. The list of tools that gets installed (and used) by vs code are available [here](https://github.com/Microsoft/vscode-go/wiki/Go-tools-that-the-Go-extension-depends-on).
 
@@ -131,12 +131,11 @@ You should be familiar enough with your editor to perform the following with a s
 - **go fmt**. Go has an opinioned formatter called `go fmt`. Your editor should be running this on every file save.
 - **Run tests**. It goes without saying that you should be able to do any of the above and then quickly re-run your tests to ensure your refactoring hasn't broken anything
 
-In addition, to help you work with your code you should be able to: 
+In addition, to help you work with your code you should be able to:
 
 - **View function signature** - You should never be unsure how to call a function in Go. Your IDE should describe a function in terms of its documentation, its parameters and what it returns.
 - **View function definition** - If it's still not clear what a function does, you should be able to jump to the source code and try and figure it out yourself.
 - **Find usages of a symbol** Being able to see the contest of a function being called can help your decision process when refactoring.
-
 
 Mastering your tools will help you concentrate on the code and reduce context switching.
 

--- a/integers.md
+++ b/integers.md
@@ -45,7 +45,7 @@ func Add(x, y int) int {
 }
 ```
 
-When you have more than one argument of the same type \(in our case two integers\) rather than having `(x int, y int)` you can shorten it to `(x, y int)`
+When you have more than one argument of the same type \(in our case two integers\) rather than having `(x int, y int)` you can shorten it to `(x, y int)`.
 
 Now run the tests and we should be happy that the test is correctly reporting what is wrong.
 
@@ -98,7 +98,7 @@ func Add(x, y int) int {
 
 ### Examples
 
-If you really want to go the extra mile you can make [examples](https://blog.golang.org/examples). You will find a lot of examples in the documentation of the standard library
+If you really want to go the extra mile you can make [examples](https://blog.golang.org/examples). You will find a lot of examples in the documentation of the standard library.
 
 Often code examples go out of date with what the actual code does because they live outside of the real code and don't get checked.
 
@@ -140,4 +140,3 @@ What we have covered:
 * Integers, addition
 * Writing better documentation so users of our code can understand its usage quickly
 * Examples of how to use our code, which are checked as part of our tests
-

--- a/iteration.md
+++ b/iteration.md
@@ -130,4 +130,3 @@ _NOTE_ by default Benchmarks are run sequentially.
 * More TDD practice
 * Learned `for`.
 * Learned how to write benchmarks
-

--- a/mocking.md
+++ b/mocking.md
@@ -2,7 +2,7 @@
 
 **[You can find all the code for this chapter here](https://github.com/quii/learn-go-with-tests/tree/master/mocking)**
 
-You have been asked to write a program which counts from 3, printing each number on a new line (with a 1 second pause) and when it reaches zero it will print "Go!" and exit. 
+You have been asked to write a program which counts from 3, printing each number on a new line (with a 1 second pause) and when it reaches zero it will print "Go!" and exit.
 
 ```
 3
@@ -17,19 +17,19 @@ We'll tackle this by writing a function called `Countdown` which we will then pu
 package main
 
 func main() {
-    Countdown()
+	Countdown()
 }
 ```
 
-While this is a pretty trivial program, to test it fully we will need as always to take an _iterative_, _test-driven_ approach. 
+While this is a pretty trivial program, to test it fully we will need as always to take an _iterative_, _test-driven_ approach.
 
-What do I mean by iterative? We make sure we take the smallest steps we can to have _useful software_. 
+What do I mean by iterative? We make sure we take the smallest steps we can to have _useful software_.
 
 We dont want to spend a long time with code that will theoretically work after some hacking because that's often how developers fall down rabit holes. **It's an important skill to be able to slice up requirements as small as you can so you can have _working software_.**
 
-Here's how we can divide our work up and iterate on it
+Here's how we can divide our work up and iterate on it:
 
-- Print 3 
+- Print 3
 - Print 3 to Go!
 - Wait a second between each line
 
@@ -52,17 +52,16 @@ func TestCountdown(t *testing.T) {
 }
 ```
 
-If anything like `buffer` is unfamiliar to you, re-read the previous section.
+If anything like `buffer` is unfamiliar to you, re-read [the previous section](dependency-injection.md).
 
-We know we want our `Countdown` function to write data somewhere and `io.Writer` is the de-facto way of capturing that as an interface in Go. 
+We know we want our `Countdown` function to write data somewhere and `io.Writer` is the de-facto way of capturing that as an interface in Go.
 
-- In `main` we will send to `os.Stdout` so our users see the countdown printed to the terminal
-- In test we will send to `bytes.Buffer` so our tests can capture what data is being generated
+- In `main` we will send to `os.Stdout` so our users see the countdown printed to the terminal.
+- In test we will send to `bytes.Buffer` so our tests can capture what data is being generated.
 
 ## Try and run the test
 
 `./countdown_test.go:11:2: undefined: Countdown`
-
 
 ## Write the minimal amount of code for the test to run and check the failing test output
 
@@ -77,7 +76,7 @@ Try again
 ```go
 ./countdown_test.go:11:11: too many arguments in call to Countdown
 	have (*bytes.Buffer)
-    want ()
+	want ()
 ```
 
 The compiler is telling you what your function signature could be, so update it.
@@ -98,7 +97,7 @@ func Countdown(out *bytes.Buffer) {
 }
 ```
 
-We're using `fmt.Fprint` which takes an `io.Writer` (like `*bytes.Buffer`) and sends a `string` to it. The test should pass. 
+We're using `fmt.Fprint` which takes an `io.Writer` (like `*bytes.Buffer`) and sends a `string` to it. The test should pass.
 
 ## Refactor
 
@@ -110,7 +109,7 @@ func Countdown(out io.Writer) {
 }
 ```
 
-Re-run the tests and they should be passing. 
+Re-run the tests and they should be passing.
 
 To complete matters, let's now wire up our function into a `main` so we have some working software to reassure ourselves we're making progress.
 
@@ -132,7 +131,7 @@ func main() {
 }
 ```
 
-Try and run the program and be amazed at your handywork. 
+Try and run the program and be amazed at your handywork.
 
 Yes this seems trivial but this approach is what I would recommend for any project. **Take a thin slice of functionality and make it work end-to-end, backed by tests.**
 
@@ -167,7 +166,7 @@ The backtick syntax is another way of creating a `string` but lets you put thing
 ```
 countdown_test.go:21: got '3' want '3
 		2
-        1
+		1
 		Go!'
 ```
 ## Write enough code to make it pass
@@ -176,12 +175,12 @@ countdown_test.go:21: got '3' want '3
 func Countdown(out io.Writer) {
 	for i := 3; i > 0; i-- {
 		fmt.Fprintln(out, i)
-    }
-    fmt.Fprint(out, "Go!")
+	}
+	fmt.Fprint(out, "Go!")
 }
 ```
 
-Use a `for` loop counting backwards with `i--` and use `fmt.Fprintln` to print to `out` with our number followed by a newline character. Finally use `fmt.Fprint` to send "Go!" aftward
+Use a `for` loop counting backwards with `i--` and use `fmt.Fprintln` to print to `out` with our number followed by a newline character. Finally use `fmt.Fprint` to send "Go!" aftward.
 
 ## Refactor
 
@@ -199,7 +198,7 @@ func Countdown(out io.Writer) {
 }
 ```
 
-If you run the program now, you should get the desired output but we dont have it as a dramatic countdown with the 1 second pauses. 
+If you run the program now, you should get the desired output but we don't have it as a dramatic countdown with the 1 second pauses.
 
 Go let's you achieve this with `time.Sleep`. Try adding it in to our code.
 
@@ -209,7 +208,7 @@ func Countdown(out io.Writer) {
 		time.Sleep(1 * time.Second)
 		fmt.Fprintln(out, i)
 	}
-	
+
 	time.Sleep(1 * time.Second)
 	fmt.Fprint(out, finalWord)
 }
@@ -220,19 +219,19 @@ If you run the program it works as we want it to.
 ## Mocking
 
 The tests still pass and the software works as intended but we have some problems:
-- Our tests take 4 seconds to run. 
-	- Every forward thinking post about software development emphasises the importance of quick feedback loops. 
+- Our tests take 4 seconds to run.
+	- Every forward thinking post about software development emphasises the importance of quick feedback loops.
 	- **Slow tests ruin developer productivity**.
 	- Imagine if the requirements get more sophisticated warranting more tests. Are we happy with 4s added to the test run for every new test of `Countdown`?
-- We have not tested an important property of our function. 
+- We have not tested an important property of our function.
 
 We have a dependency on `Sleep`ing which we need to extract so we can then control it in our tests.
 
-If we can _mock_ `time.Sleep` we can use _dependency injection_ to use it instead of a "real" `time.Sleep` and then we can **spy on the calls** to make assertions on them. 
+If we can _mock_ `time.Sleep` we can use _dependency injection_ to use it instead of a "real" `time.Sleep` and then we can **spy on the calls** to make assertions on them.
 
 ## Write the test first
 
-Let's define our dependency as an interface. This lets us then use a _real_ Sleeper in `main` and a _spy sleeper_ in our tests. By using an interface our `Countdown` function is obvlivious to this and adds some flexibility for the caller.
+Let's define our dependency as an interface. This lets us then use a _real_ Sleeper in `main` and a _spy sleeper_ in our tests. By using an interface our `Countdown` function is oblivious to this and adds some flexibility for the caller.
 
 ```go
 type Sleeper interface {
@@ -240,12 +239,9 @@ type Sleeper interface {
 }
 ```
 
-I made a design decision that our `Countdown` function would not be responsible
-for how long the sleep is. This simplifies our code a little for now at least
-and means a user of our function can configure that sleepiness however they
-like.
+I made a design decision that our `Countdown` function would not be responsible for how long the sleep is. This simplifies our code a little for now at least and means a user of our function can configure that sleepiness however they like.
 
-Now we need to make a _mock_ of it for our tests to use. 
+Now we need to make a _mock_ of it for our tests to use.
 
 ```go
 type SpySleeper struct {
@@ -288,7 +284,7 @@ Go!`
 
 ```
 too many arguments in call to Countdown
-	have (*bytes.Buffer, Sleeper)
+	have (*bytes.Buffer, *SpySleeper)
 	want (io.Writer)
 ```
 
@@ -328,9 +324,7 @@ func (o *ConfigurableSleeper) Sleep() {
 }
 ```
 
-I decided to make a little extra effort and make it so our real sleeper is
-configurable but you could just as easily not bother and hard-code it for
-1 second.
+I decided to make a little extra effort and make it so our real sleeper is configurable but you could just as easily not bother and hard-code it for 1 second.
 
 We can then use it in our real application like so
 
@@ -352,7 +346,7 @@ func Countdown(out io.Writer, sleeper Sleeper) {
 		fmt.Fprintln(out, i)
 	}
 
-	sleeper.sleep()
+	sleeper.Sleep()
 	fmt.Fprint(out, finalWord)
 }
 ```
@@ -361,7 +355,7 @@ The test should pass and no longer taking 4 seconds.
 
 ### Still some problems
 
-There's still another important property we haven't tested. 
+There's still another important property we haven't tested.
 
 `Countdown` should sleep before the first print and then after each one until the last, e.g:
 
@@ -372,7 +366,7 @@ There's still another important property we haven't tested.
 - `Sleep`
 - etc
 
-Our latest change only asserts that it has slept 4 times, but those sleeps could occur out of sequence
+Our latest change only asserts that it has slept 4 times, but those sleeps could occur out of sequence.
 
 When writing tests if you're not confident that your tests are giving you sufficient confidence, just break it! (make sure you have commited your changes to source control first though). Change the code to the following
 
@@ -415,36 +409,35 @@ const write = "write"
 const sleep = "sleep"
 ```
 
-Our `CountdownOperationsSpy` implements both `io.Writer` and `Sleeper`, recording every call into one slice. In this test we're only concerned about the order of operations, so just recording them as list of named operations is sufficient. 
+Our `CountdownOperationsSpy` implements both `io.Writer` and `Sleeper`, recording every call into one slice. In this test we're only concerned about the order of operations, so just recording them as list of named operations is sufficient.
 
 We can now add a sub-test into our test suite.
 
-
 ```go
 t.Run("sleep after every print", func(t *testing.T) {
-    spySleepPrinter := &CountdownOperationsSpy{}
-    Countdown(spySleepPrinter, spySleepPrinter)
+	spySleepPrinter := &CountdownOperationsSpy{}
+	Countdown(spySleepPrinter, spySleepPrinter)
 
-    want := []string{
-    	sleep,
-        write,
-        sleep,
-        write,
-        sleep,
-        write,
-        sleep,
-        write,
-    }
+	want := []string{
+		sleep,
+		write,
+		sleep,
+		write,
+		sleep,
+		write,
+		sleep,
+		write,
+	}
 
-    if !reflect.DeepEqual(want, spySleepPrinter.Calls) {
-        t.Errorf("wanted calls %v got %v", want, spySleepPrinter.Calls)
-    }
+	if !reflect.DeepEqual(want, spySleepPrinter.Calls) {
+		t.Errorf("wanted calls %v got %v", want, spySleepPrinter.Calls)
+	}
 })
 ```
 
-This test should now fail. Revert it back and the new test should pass. 
+This test should now fail. Revert it back and the new test should pass.
 
-We now have two tests spying on the `Sleeper` so we can now refactor our test so one is testing what is being printed and the other one is ensuring we're sleeping in between the prints. Finally we can delete our first spy as it's not used anymore. 
+We now have two tests spying on the `Sleeper` so we can now refactor our test so one is testing what is being printed and the other one is ensuring we're sleeping in between the prints. Finally we can delete our first spy as it's not used anymore.
 
 ```go
 func TestCountdown(t *testing.T) {
@@ -490,24 +483,24 @@ We now have our function and its 2 important properties properly tested.
 
 ## But isn't mocking evil?
 
-You may have heard mocking is evil. Just like anything in software development it can be used for evil, just like DRY. 
+You may have heard mocking is evil. Just like anything in software development it can be used for evil, just like [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
 
-People normally get in to a bad state when they don't _listen to their tests_ and are _not respecting the refactoring stage_. 
+People normally get in to a bad state when they don't _listen to their tests_ and are _not respecting the refactoring stage_.
 
 If your mocking code is becoming complicated or you are having to mock out lots of things to test something, you should _listen_ to that bad feeling and think about your code. Usually it is a sign of
 
-- The thing you are testing is having to do too many things.
-	- Break the module apart so it does less
+- The thing you are testing is having to do too many things
+  - Break the module apart so it does less
 - Its dependencies are too fine-grained
-	- Think about how you can consolidate some of these dependencies into one meaningful module.
+  - Think about how you can consolidate some of these dependencies into one meaningful module
 - Your test is too concerned with implementation details
-	- Favour testing expected behaviour rather than the implementation
+  - Favour testing expected behaviour rather than the implementation
 
-Normally a lot of mocking points to _bad abstraction_ in your code. 
+Normally a lot of mocking points to _bad abstraction_ in your code.
 
-**What people see here is a weakness in TDD but it is actually a strength**, more often than not poor test code is a result of bad design or put more nicely, well-designed code is easy to test. 
+**What people see here is a weakness in TDD but it is actually a strength**, more often than not poor test code is a result of bad design or put more nicely, well-designed code is easy to test.
 
-### But mocks and tests are still making my life hard! 
+### But mocks and tests are still making my life hard!
 
 Ever run into this situation?
 
@@ -517,11 +510,11 @@ Ever run into this situation?
 
 This is usually a sign of you testing too much _implementation detail_. Try to make it so your tests are testing _useful behaviour_ unless the implementation is really important to how the system runs.
 
-It is sometimes hard to know _what level_ to test exactly but here are some thought processes and rules I try to follow
+It is sometimes hard to know _what level_ to test exactly but here are some thought processes and rules I try to follow:
 
 - **The definition of refactoring is that the code changes but the behaviour stays the same**. If you have decided to do some refactoring in theory you should be able to do make the commit without any test changes. So when writing a test ask yourself
-    - Am i testing the behaviour I want or the implementation details?
-    - If i were to refactor this code, would I have to make lots of changes to the tests?
+  - Am i testing the behaviour I want or the implementation details?
+  - If i were to refactor this code, would I have to make lots of changes to the tests?
 - Although Go lets you test private functions, I would avoid it as private functions are to do with implementation.
 - I feel like if a test is working with **more than 3 mocks then it is a red flag** - time for a rethink on the design
 - Use spies with caution. Spies let you see the insides of the algorithm you are writing which can be very useful but that means a tighter coupling between your test code and the implementation. **Be sure you actually care about these details if you're going to spy on them**
@@ -536,7 +529,7 @@ As always, rules in software development aren't really rules and there can be ex
 - Once you have some working software it should be easier to _iterate with small steps_ until you arrive at the software you need.
 
 ### Mocking
- 
+
 - **Without mocking important areas of your code will be untested**. In our case we would not be able to test that our code paused between each print but there are countless other examples. Calling a service that _can_ fail? Wanting to test your system in a particular state? It is very hard to test these scenarios without mocking.
 - Without mocks you may have to set up databases and other third parties things just to test simple business rules. You're likely to have slow tests, resulting in **slow feedback loops**.
 - By having to spin up a database or a webservice to test something you're likely to have **fragile tests** due to the unreliability of such services.

--- a/pointers-and-errors.md
+++ b/pointers-and-errors.md
@@ -8,7 +8,7 @@ At some point you may wish to use structs to manage state, exposing methods to l
 
 **Fintech loves Go** and uhhh bitcoins? so let's show what an amazing banking system we can make.
 
-Let's make a `Wallet` struct which let's us deposit `Bitcoin`
+Let's make a `Wallet` struct which let's us deposit `Bitcoin`.
 
 ## Write the test first
 
@@ -107,7 +107,7 @@ In Go, **when you call a function or a method the arguments are** _**copied**_.
 
 When calling `func (w Wallet) Deposit(amount int)` the `w` is a copy of whatever we called the method from.
 
-Without getting too computer-sciency, when you create a value - like a wallet, it is stored somewhere in memory. You can find out what the _address_ of that bit of memory with `&myVal`
+Without getting too computer-sciency, when you create a value - like a wallet, it is stored somewhere in memory. You can find out what the _address_ of that bit of memory with `&myVal`.
 
 Experiment by adding some prints to your code
 
@@ -205,7 +205,7 @@ func TestWallet(t *testing.T) {
 }
 ```
 
-To make `Bitcoin` you just use the syntax `Bitcoin(999)`
+To make `Bitcoin` you just use the syntax `Bitcoin(999)`.
 
 An interesting property of type aliasing is that you can also declare _methods_ on them. This can be very useful when you want to add some domain specific functionality on top of existing types.
 
@@ -277,7 +277,6 @@ func TestWallet(t *testing.T) {
             t.Errorf("got %s want %s", got, want)
         }
     })
-
 }
 ```
 
@@ -339,7 +338,7 @@ How do we signal a problem when using `Withdraw` ?
 
 In Go, if you want to indicate an error it is idiomatic for your function to return an `err` for the caller to check and act on.
 
-Let's try this out in a test
+Let's try this out in a test.
 
 ## Write the test first
 
@@ -357,7 +356,7 @@ t.Run("Withdraw insufficient funds", func(t *testing.T) {
 })
 ```
 
-We want `Withdraw` to return an error _if_ you try to take out more than you have and the balance should stay the same
+We want `Withdraw` to return an error _if_ you try to take out more than you have and the balance should stay the same.
 
 We then check an error has returned by failing the test if it is `nil`.
 
@@ -380,7 +379,7 @@ func (w *Wallet) Withdraw(amount Bitcoin) error {
 }
 ```
 
-Again, it is very important to just write enough code to satisfy the compiler. We correct our `Withdraw` method to return `error` and for now we have to return _something_ so let's just return `nil`
+Again, it is very important to just write enough code to satisfy the compiler. We correct our `Withdraw` method to return `error` and for now we have to return _something_ so let's just return `nil`.
 
 ## Write enough code to make it pass
 
@@ -398,7 +397,7 @@ func (w *Wallet) Withdraw(amount Bitcoin) error {
 
 Remember to import `errors` into your code.
 
-`errors.New` creates a new `error` with a message of your choosing
+`errors.New` creates a new `error` with a message of your choosing.
 
 ## Refactor
 
@@ -426,7 +425,7 @@ t.Run("Withdraw insufficient funds", func(t *testing.T) {
 
 Hopefully when returning an error of "oh no" you were thinking that we _might_ iterate on that because it doesn't seem that useful to return.
 
-Assuming that the error ultimately gets returned to the user, let's update our test to assert on some kind of error message rather than just the existence of an error
+Assuming that the error ultimately gets returned to the user, let's update our test to assert on some kind of error message rather than just the existence of an error.
 
 ## Write the test first
 
@@ -629,7 +628,7 @@ func assertError(t *testing.T, got error, want error) {
 ### Pointers
 
 * Go copies values when you pass them to functions/methods so if you're writing a function that needs to mutate state you'll need it to take a pointer to the thing you want to change.
-* The fact that Go takes a copy of values is useful a lot of the time but sometimes you wont want your system to make a copy of something, in which case you need to pass a reference. Examples could be very large data or perhaps things you intend only to have one instance of \(like database connection pools\)
+* The fact that Go takes a copy of values is useful a lot of the time but sometimes you wont want your system to make a copy of something, in which case you need to pass a reference. Examples could be very large data or perhaps things you intend only to have one instance of \(like database connection pools\).
 
 ### nil
 
@@ -639,10 +638,10 @@ func assertError(t *testing.T, got error, want error) {
 
 ### Errors
 
-* Errors are the way to signify failure when calling a function/method
+* Errors are the way to signify failure when calling a function/method.
 * By listening to our tests we concluded that checking for a string in an error would result in a flaky test. So we refactored to use a meaningful value instead and this resulted in easier to test code and concluded this would be easier for users of our API too.
 * This is not the end of the story with error handling, you can do more sophisticated things but this is just an intro. Later sections will cover more strategies.
-* [Don’t just check errors, handle them gracefully](https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully) 
+* [Don’t just check errors, handle them gracefully](https://dave.cheney.net/2016/04/27/dont-just-check-errors-handle-them-gracefully)
 
 ### Create new types from existing ones
 

--- a/select.md
+++ b/select.md
@@ -2,14 +2,14 @@
 
 **[You can find all the code for this chapter here](https://github.com/quii/learn-go-with-tests/tree/master/select)**
 
-You have been asked to make a function called `WebsiteRacer` which takes two URLs and "races" them by hitting them with a HTTP GET and returning the URL which returned first. If none of them return within 10 seconds then it should return an `error`
+You have been asked to make a function called `WebsiteRacer` which takes two URLs and "races" them by hitting them with a HTTP GET and returning the URL which returned first. If none of them return within 10 seconds then it should return an `error`.
 
 For this we will be using
 
 - `net/http` to make the HTTP calls.
 - `net/http/httptest` to help us test them.
 - goroutines.
-- `select` to synchronise processes. 
+- `select` to synchronise processes.
 
 ## Write the test first
 
@@ -34,7 +34,6 @@ We know this isn't perfect and has problems but it will get us going. It's impor
 ## Try to run the test
 
 `./racer_test.go:14:9: undefined: Racer`
-
 
 ## Write the minimal amount of code for the test to run and check the failing test output
 
@@ -66,10 +65,10 @@ func Racer(a, b string) (winner string) {
 }
 ```
 
-For each url: 
+For each url:
 
-1. We use `time.Now()` to record just before we try and get the `URL`
-2. Then we use [`http.Get`](https://golang.org/pkg/net/http/#Client.Get) to try and get the contents of the `URL`. This function returns a [`http.Response`](https://golang.org/pkg/net/http/#Response) and an `error` but so far we are not interested in these values
+1. We use `time.Now()` to record just before we try and get the `URL`.
+2. Then we use [`http.Get`](https://golang.org/pkg/net/http/#Client.Get) to try and get the contents of the `URL`. This function returns a [`http.Response`](https://golang.org/pkg/net/http/#Response) and an `error` but so far we are not interested in these values.
 3. `time.Since` takes the start time and returns a `time.Duration` of the difference.
 
 Once we have done this we simply compare the durations to see which is the quickest.
@@ -80,7 +79,7 @@ This may or may not make the test pass for you. The problem is we're reaching ou
 
 Testing code that uses HTTP is so common that Go has tools in the standard library to help you test it.
 
-In the mocking and dependency injection chapters we covered how ideally we dont want to be relying on external services to test our code because they can be 
+In the mocking and dependency injection chapters we covered how ideally we dont want to be relying on external services to test our code because they can be
 
 - Slow
 - Flaky
@@ -119,11 +118,11 @@ func TestRacer(t *testing.T) {
 
 The syntax may look a bit busy but just take your time.
 
-`httptest.NewServer` takes a `http.HandlerFunc` which we are sending in via an _anonymous function_. 
+`httptest.NewServer` takes a `http.HandlerFunc` which we are sending in via an _anonymous function_.
 
 `http.HandlerFunc` is a type that looks like this: `type HandlerFunc func(ResponseWriter, *Request)`
 
-All it's really saying is it needs a function that takes a `ResponseWriter` and a `Request`, which is not too surprising for a HTTP server
+All it's really saying is it needs a function that takes a `ResponseWriter` and a `Request`, which is not too surprising for a HTTP server.
 
 It turns out there's really no extra magic here, **this is also how you would write a _real_ HTTP server in Go**. The only difference is we are wrapping it in a `httptest.NewServer` which makes it easier to use with testing, as it finds an open port to listen on and then you can close it when you're done with your test.
 
@@ -186,21 +185,22 @@ func makeDelayedServer(delay time.Duration) *httptest.Server {
 
 We've refactored creating our fake servers into a function called `makeDelayedServer` to move some uninteresting code out of the test and reduce repetition.
 
-#### `defer`
-By prefixing a function call with `defer` it will now call that function _at the end of the containing function_. 
+### `defer`
 
-Sometimes you will need to cleanup resources, such as closing a file or in our case closing a server so that it does not continue to listen to a port. 
+By prefixing a function call with `defer` it will now call that function _at the end of the containing function_.
+
+Sometimes you will need to cleanup resources, such as closing a file or in our case closing a server so that it does not continue to listen to a port.
 
 You want this to execute at the end of the function, but keep the instruction near where you created the server for the benefit of future readers of the code.
 
-Our refactoring is an improvement and is a reasonable solution given the Go features covered so far, but we can make the solution simpler. 
+Our refactoring is an improvement and is a reasonable solution given the Go features covered so far, but we can make the solution simpler.
 
 ### Synchronising processes
 
-- Why are we testing the speeds of the websites one after another when Go is great at concurrency? We should be able to check both at the same time
-- We don't really care about _the exact response times_ of the requests, we just want to know which one comes back first. 
+- Why are we testing the speeds of the websites one after another when Go is great at concurrency? We should be able to check both at the same time.
+- We don't really care about _the exact response times_ of the requests, we just want to know which one comes back first.
 
-To do this, we're going to introduce a new construct called `select` which helps us synchronise processes really easily and clearly.  
+To do this, we're going to introduce a new construct called `select` which helps us synchronise processes really easily and clearly.
 
 ```go
 func Racer(a, b string) (winner string) {
@@ -221,43 +221,44 @@ func ping(url string) chan bool {
 	return ch
 }
 ```
+
 #### `ping`
 
 We have defined a function `ping` which creates a `chan bool` and returns it.
 
 In our case, we don't really _care_ what the type sent in the channel, _we just want to send a signal_ to say we're finished so booleans are fine.
 
-Inside the same function we start a goroutine which will send a signal into that channel once we have completed `http.Get(url)`
+Inside the same function we start a goroutine which will send a signal into that channel once we have completed `http.Get(url)`.
 
 #### `select`
 
-If you recall from the concurrency chapter, you can wait for values to be sent to a channel with `myVar := <-ch`. This is a _blocking_ call, as you're waiting for a value. 
+If you recall from the concurrency chapter, you can wait for values to be sent to a channel with `myVar := <-ch`. This is a _blocking_ call, as you're waiting for a value.
 
-What `select` lets you do is wait on _multiple_ channels. The first one to send a value "wins" and the code underneath the `case` is executed. 
+What `select` lets you do is wait on _multiple_ channels. The first one to send a value "wins" and the code underneath the `case` is executed.
 
 We use `ping` in our `select` to set up two channels for each of our `URL`s. Whichever one writes to its channel first will have its code executed in the `select`, which results in its `URL` being returned (and being the winner).
 
-After these changes the intent behind our code is very clear and the implementation is actually simpler.  
+After these changes the intent behind our code is very clear and the implementation is actually simpler.
 
 ### Timeouts
 
-Our final requirement was to return an error if `Racer` takes longer than 10 seconds. 
+Our final requirement was to return an error if `Racer` takes longer than 10 seconds.
 
 ## Write the test first
 
 ```go
 t.Run("returns an error if a server doesn't respond within 10s", func(t *testing.T) {
-    serverA := makeDelayedServer(11 * time.Second)
-    serverB := makeDelayedServer(12 * time.Second)
+	serverA := makeDelayedServer(11 * time.Second)
+	serverB := makeDelayedServer(12 * time.Second)
 
-    defer serverA.Close()
-    defer serverB.Close()
-    
-    _, err := Racer(serverA.URL, serverB.URL)
+	defer serverA.Close()
+	defer serverB.Close()
 
-    if err == nil {
-        t.Error("expected an error but didn't get one")
-    }
+	_, err := Racer(serverA.URL, serverB.URL)
+
+	if err == nil {
+		t.Error("expected an error but didn't get one")
+	}
 })
 ```
 
@@ -282,14 +283,14 @@ func Racer(a, b string) (winner string, error error) {
 
 Change the signature of `Racer` to return the winner and an `error`. Return `nil` for our happy cases.
 
-The compiler will complain about your _first test_ only looking for one value so change that line to `got, _ := Racer(slowURL, fastURL)`, knowing that we should check we _don't_ get an error in our happy scenario. 
+The compiler will complain about your _first test_ only looking for one value so change that line to `got, _ := Racer(slowURL, fastURL)`, knowing that we should check we _don't_ get an error in our happy scenario.
 
 If you run it now after 11 seconds it will fail
 
 ```
 --- FAIL: TestRacer (12.00s)
-    --- FAIL: TestRacer/returns_an_error_if_a_server_doesn't_respond_within_10s (12.00s)
-    	racer_test.go:40: expected an error but didn't get one
+	--- FAIL: TestRacer/returns_an_error_if_a_server_doesn't_respond_within_10s (12.00s)
+		racer_test.go:40: expected an error but didn't get one
 ```
 
 ## Write enough code to make it pass
@@ -307,15 +308,15 @@ func Racer(a, b string) (winner string, error error) {
 }
 ```
 
-`time.After` is a very handy function when using `select`. Although it didn't happen in our case you can potentially write code that blocks forever if the channels you're listening on never return a value. `time.After` returns a `chan` (like `ping`) and will send a signal down it after the amount of time you define. 
+`time.After` is a very handy function when using `select`. Although it didn't happen in our case you can potentially write code that blocks forever if the channels you're listening on never return a value. `time.After` returns a `chan` (like `ping`) and will send a signal down it after the amount of time you define.
 
-For us this is perfect; if `a` or `b` manage to return they win, but if we get to 10 seconds then our `time.After` will send a signal and we'll return an `error`
+For us this is perfect; if `a` or `b` manage to return they win, but if we get to 10 seconds then our `time.After` will send a signal and we'll return an `error`.
 
 ### Slow tests
 
-The problem we have is that this test takes 10 seconds to run. For such a simple bit of logic this doesn't feel great. 
+The problem we have is that this test takes 10 seconds to run. For such a simple bit of logic this doesn't feel great.
 
-What we can do is make the timeout configurable so in our test we can have a very short timeout and then when the code is used in the real world it can be set to 10 seconds. 
+What we can do is make the timeout configurable so in our test we can have a very short timeout and then when the code is used in the real world it can be set to 10 seconds.
 
 ```go
 func Racer(a, b string, timeout time.Duration) (winner string, error error) {
@@ -330,7 +331,7 @@ func Racer(a, b string, timeout time.Duration) (winner string, error error) {
 }
 ```
 
-Our tests now wont compile because we're not supplying a timeout
+Our tests now wont compile because we're not supplying a timeout.
 
 Before rushing in to add this default value to both our tests let's _listen to them_.
 
@@ -375,7 +376,7 @@ func TestRacer(t *testing.T) {
 
 		want := fastURL
 		got, err := Racer(slowURL, fastURL)
-		
+
 		if err != nil {
 			t.Fatalf("did not expect an error but got one %v", err)
 		}
@@ -399,7 +400,7 @@ func TestRacer(t *testing.T) {
 }
 ```
 
-I added one final check on the first test to verify we don't get an `error`
+I added one final check on the first test to verify we don't get an `error`.
 
 ## Wrapping up
 
@@ -411,4 +412,4 @@ I added one final check on the first test to verify we don't get an `error`
 ### `httptest`
 
 - Convenient way of creating test servers so you can have reliable and controllable tests.
-- Uses the same interfaces as the "real" `net/http` servers which is consistent and less for you to learn
+- Uses the same interfaces as the "real" `net/http` servers which is consistent and less for you to learn.

--- a/structs-methods-and-interfaces.md
+++ b/structs-methods-and-interfaces.md
@@ -2,7 +2,7 @@
 
 **[You can find all the code for this chapter here](https://github.com/quii/learn-go-with-tests/tree/master/structs)**
 
-Suppose that we need some geometry code to calculate the perimeter of a rectangle given a height and width. We can write a `Perimeter(width float64, height float64)` function, where `float64` is for floating-point numbers like `123.45`
+Suppose that we need some geometry code to calculate the perimeter of a rectangle given a height and width. We can write a `Perimeter(width float64, height float64)` function, where `float64` is for floating-point numbers like `123.45`.
 
 The TDD cycle should be pretty familiar to you by now.
 
@@ -33,7 +33,7 @@ func Perimeter(width float64, height float64) float64 {
 }
 ```
 
-Results in `shapes_test.go:10: got 0 want 40`
+Results in `shapes_test.go:10: got 0 want 40`.
 
 ## Write enough code to make it pass
 
@@ -205,9 +205,9 @@ But you cannot in Go
 
 `./shapes.go:20:32: Area redeclared in this block`
 
-We have two choices
+We have two choices:
 
-* You can have functions with the same name declared in different _packages_. So we could create our `Area(Circle)` in a new package, but that feels overkill here
+* You can have functions with the same name declared in different _packages_. So we could create our `Area(Circle)` in a new package, but that feels overkill here.
 * We can define [_methods_](https://golang.org/ref/spec#Method_declarations) on our newly defined types instead.
 
 ### What are methods?
@@ -290,7 +290,7 @@ It is a convention in Go to have the receiver variable be the first letter of th
 r Rectangle
 ```
 
-If you try to re-run the tests they should now compile and give you some failing output
+If you try to re-run the tests they should now compile and give you some failing output.
 
 ## Write enough code to make it pass
 
@@ -385,7 +385,7 @@ This kind of approach of using interfaces to declare **only what you need** is v
 
 ## Further refactoring
 
-Now that you have some understanding of structs we can now introduce "table driven tests"
+Now that you have some understanding of structs we can now introduce "table driven tests".
 
 [Table driven tests](https://github.com/golang/go/wiki/TableDrivenTests) are useful when you want to build a list of test cases that can be tested in the same manner.
 
@@ -494,7 +494,7 @@ And our tests pass!
 
 ## Refactor
 
-Again, the implementation is fine but our tests could do with some improvement
+Again, the implementation is fine but our tests could do with some improvement.
 
 When you scan this
 
@@ -516,7 +516,7 @@ Let's see what looks like
         {shape: Triangle{Base: 12, Height: 6}, want: 36.0},
 ```
 
-In [Test-Driven Development by Example](https://g.co/kgs/yCzDLF) Kent Beck refactors some tests to a point and asserts
+In [Test-Driven Development by Example](https://g.co/kgs/yCzDLF) Kent Beck refactors some tests to a point and asserts:
 
 > The test speaks to us more clearly, as if it were an assertion of truth, **not a sequence of operations**
 
@@ -524,9 +524,9 @@ In [Test-Driven Development by Example](https://g.co/kgs/yCzDLF) Kent Beck refac
 
 Now our tests \(at least the list of cases\) make assertions of truth about shapes and their areas.
 
-#### Make sure your test output is helpful
+## Make sure your test output is helpful
 
-Remember earlier when we were implementing `Triangle` and we had the failing test? It printed `shapes_test.go:31: got 0.00 want 36.00`
+Remember earlier when we were implementing `Triangle` and we had the failing test? It printed `shapes_test.go:31: got 0.00 want 36.00`.
 
 We knew this was in relation to `Triangle` because we were just working with it, but what if a bug slipped in to the system in one of 20 cases in the table. How would a developer know which case failed? This is not a great experience for the developer, they will have to manually look through the cases to find out which case actually failed.
 
@@ -542,7 +542,7 @@ By wrapping each case in a `t.Run` you will have clearer test output on failures
         shapes_test.go:33: main.Rectangle{Width:12, Height:6} got 72.00 want 72.10
 ```
 
-And you can run specific tests within your table with `go test -run TestArea/Rectangle`
+And you can run specific tests within your table with `go test -run TestArea/Rectangle`.
 
 Here is our final test code which captures this
 
@@ -587,4 +587,3 @@ This was an important chapter because we are now starting to define our own type
 Interfaces are a great tool for hiding complexity away from other parts of the system. In our case our test helper _code_ did not need to know the exact shape it was asserting on, only how to "ask" for it's area.
 
 As you become more familiar with Go you start to see the real strength of interfaces and the standard library. You'll learn about interfaces defined in the standard library that are used _everywhere_ and by implementing them against your own types you can very quickly re-use a lot of great functionality.
-

--- a/template.md
+++ b/template.md
@@ -8,6 +8,5 @@ Some intro
 ## Write enough code to make it pass
 ## Refactor
 
-
 ## Repeat for new requirements
 ## Wrapping up


### PR DESCRIPTION
Hi @quii, Thank you for the great book!

With this PR, I introduced [MarkdownLint](https://github.com/markdownlint/markdownlint) to you. I add it to CI stage. When the doc style breaks the [rules](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md) the CI will fail([example](https://travis-ci.org/pityonline/learn-go-with-tests/jobs/372647823)), you may review what rules are used in `.mdlrc`.

It seems a lot of changes, but actually not that a lot, just trivial style matters. You may review it via `git diff --word-diff origin/master`.