### PR TITLE
add spelling check and Go Report Card

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install: true
 
 stages:
   - build
+  - spelling
   - markdownlint
 
 jobs:
@@ -15,6 +16,10 @@ jobs:
       script:
         - go get -u golang.org/x/lint/golint
         - ./build.sh
+    - stage: spelling
+      script:
+        - go get -u github.com/client9/misspell/cmd/misspell
+        - misspell -error .
     - stage: markdownlint
       script:
         - gem install mdl

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 _Or learn test-driven development with Go_
 
 ![Build Status](https://travis-ci.org/quii/learn-go-with-tests.svg?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/quii/learn-go-with-tests)](https://goreportcard.com/report/github.com/quii/learn-go-with-tests)
 
 [You can read this on Gitbook](https://quii.gitbook.io/learn-go-with-tests)
 

--- a/install-go.md
+++ b/install-go.md
@@ -32,7 +32,7 @@ If you are going to deploy your programs to linux based servers, you should enab
 brew install go --cross-compile-common
 ```
 
-*You should follow any instructions reccomended by your package manager, not these may be host os specific*.
+*You should follow any instructions recommended by your package manager, not these may be host os specific*.
 
 You can verify the installation with:
 
@@ -70,7 +70,7 @@ At this point you can _go get_ and the src/package/bin will be installed correct
 
 ## Go Editor
 
-Editor preference is very individualistic, you may already have a preference that supports Go.  If you don't you should consider an Editor such as [Visual Studio Code](https://code.visualstudio.com), which has execptional Go support.
+Editor preference is very individualistic, you may already have a preference that supports Go.  If you don't you should consider an Editor such as [Visual Studio Code](https://code.visualstudio.com), which has exceptional Go support.
 
 To install vs code using brew, because this is a GUI application you need an extension to homebrew called cask to support install vs code.
 

--- a/mocking.md
+++ b/mocking.md
@@ -368,7 +368,7 @@ There's still another important property we haven't tested.
 
 Our latest change only asserts that it has slept 4 times, but those sleeps could occur out of sequence.
 
-When writing tests if you're not confident that your tests are giving you sufficient confidence, just break it! (make sure you have commited your changes to source control first though). Change the code to the following
+When writing tests if you're not confident that your tests are giving you sufficient confidence, just break it! (make sure you have committed your changes to source control first though). Change the code to the following
 
 ```go
 func Countdown(out io.Writer, sleeper Sleeper) {


### PR DESCRIPTION
* spelling check stage of CI will check all wrong spellings by [misspell](https://github.com/client9/misspell), even in documents.
* [Go Report Card](https://github.com/gojp/goreportcard) will generate a report on the quality of an open source go project. It has several checks with go toolchains, also a bundled misspell but only check the Go code without docs.

Because spelling check runs first on all files in CI, Go Report Card won't find any problem with it's bundled misspell.

Closes #9