### PR TITLE
Update structs-methods-and-interfaces.md

### DIFF
--- a/structs-methods-and-interfaces.md
+++ b/structs-methods-and-interfaces.md
@@ -410,7 +410,7 @@ func TestArea(t *testing.T) {
 }
 ```
 
-The only new syntax here is creating an "anonymous struct", areaTests. We are declaring a slice of structs by using `[]struct` with two fields, the `shape` and the `want`. Then we fill the array with cases.
+The only new syntax here is creating an "anonymous struct", areaTests. We are declaring a slice of structs by using `[]struct` with two fields, the `shape` and the `want`. Then we fill the slice with cases.
 
 We then iterate over them just like we do any other slice, using the struct fields to run our tests.
 


### PR DESCRIPTION
Error calling []struct an array.  It could be confusing to absolute beginners.  It is correctly called a slice in the following line.