### PR TITLE
Chore: add _book/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 .idea/
 *.iml
+
+# Book build output
+_book/
+
+# eBook build output
+*.epub
+*.mobi
+*.pdf


### PR DESCRIPTION
Just for keep a clean work directory after `gitbook serve`.