### PR TITLE
add the t.Helper() method

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -519,6 +519,7 @@ Our tests have some repeated code around assertion again, let's extract that int
 func TestSumAllTails(t *testing.T) {
 
     checkSums := func(t *testing.T, got, want []int) {
+        t.Helper()
         if !reflect.DeepEqual(got, want) {
             t.Errorf("got %v want %v", got, want)
         }


### PR DESCRIPTION
The checkSums function was missing the t.Helper() method.