### PR TITLE
Fix a code mistake

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -160,7 +160,7 @@ func TestSearch(t *testing.T) {
     })
 
     t.Run("unknown word", func(t *testing.T) {
-        _, err := dictionary.Search("test")
+        _, err := dictionary.Search("unknown")
         want := "could not find the word you were looking for"
 
         if err == nil {


### PR DESCRIPTION
Replace "test" with "unknown" as an input in test, when searching for an unknown word in the dictionary.