### PR TITLE
Fix a code snippet for failing test

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -164,10 +164,10 @@ func TestSearch(t *testing.T) {
         want := "could not find the word you were looking for"
 
         if err == nil {
-            t.Error("expected to get an error.")
+            t.Fatal("expected to get an error.")
         }
 
-        assertStrings(t, got.Error(), want)
+        assertStrings(t, err.Error(), want)
     })
 }
 ```


### PR DESCRIPTION
* replace `t.Error` with `t.Fatal`, so that the test stops, if we don't have an error;
* replace `got` with `err`, as `err` is the actual object we can call `Error()` on, here `got` is not defined