### PR TITLE
Add a missing space and remove a word

### DIFF
--- a/integers.md
+++ b/integers.md
@@ -130,9 +130,9 @@ $ go test -v
 --- PASS: ExampleAdd (0.00s)
 ```
 
-Please note that the example function will not be executed if you remove the comment "//Output: 6".Although the function will be compiled, it won't be executed.
+Please note that the example function will not be executed if you remove the comment "//Output: 6". Although the function will be compiled, it won't be executed.
 
-By adding this code in the example will appear in the documentation inside `godoc` making your code even more accessible.
+By adding this code the example will appear in the documentation inside `godoc`, making your code even more accessible.
 
 To try this out, run `godoc -http=:6060` and navigate to `http://localhost:6060/pkg/`
 


### PR DESCRIPTION
The extra 'in' in that sentence didn't feel right when reading it. Maybe it's possible to keep it and add a comma after it instead if you want.

I'll probably keep submitting these small changes to each chapter as I read them (if I find anything to change).