### PR TITLE
Fix name of tests for recording wins of new players

### DIFF
--- a/io.md
+++ b/io.md
@@ -630,7 +630,7 @@ We now need to handle the scenario of recording wins of new players.
 ## Write the test first
 
 ```go
-t.Run("store wins for existing players", func(t *testing.T) {
+t.Run("store wins for new players", func(t *testing.T) {
     database, cleanDatabase := createTempFile(t, `[
         {"Name": "Cleo", "Wins": 10},
         {"Name": "Chris", "Wins": 33}]`)
@@ -649,8 +649,8 @@ t.Run("store wins for existing players", func(t *testing.T) {
 ## Try to run the test
 
 ```
-=== RUN   TestFileSystemStore/store_wins_for_existing_players#01
-    --- FAIL: TestFileSystemStore/store_wins_for_existing_players#01 (0.00s)
+=== RUN   TestFileSystemStore/store_wins_for_new_players#01
+    --- FAIL: TestFileSystemStore/store_wins_for_new_players#01 (0.00s)
         FileSystemStore_test.go:86: got 0 want 1
 ```
 

--- a/io/v4/FileSystemStore_test.go
+++ b/io/v4/FileSystemStore_test.go
@@ -77,7 +77,7 @@ func TestFileSystemStore(t *testing.T) {
 		assertScoreEquals(t, got, want)
 	})
 
-	t.Run("store wins for existing players", func(t *testing.T) {
+	t.Run("store wins for new players", func(t *testing.T) {
 		database, cleanDatabase := createTempFile(t, `[
 			{"Name": "Cleo", "Wins": 10},
 			{"Name": "Chris", "Wins": 33}]`)

--- a/io/v5/FileSystemStore_test.go
+++ b/io/v5/FileSystemStore_test.go
@@ -77,7 +77,7 @@ func TestFileSystemStore(t *testing.T) {
 		assertScoreEquals(t, got, want)
 	})
 
-	t.Run("store wins for existing players", func(t *testing.T) {
+	t.Run("store wins for new players", func(t *testing.T) {
 		database, cleanDatabase := createTempFile(t, `[
 			{"Name": "Cleo", "Wins": 10},
 			{"Name": "Chris", "Wins": 33}]`)

--- a/io/v6/FileSystemStore_test.go
+++ b/io/v6/FileSystemStore_test.go
@@ -77,7 +77,7 @@ func TestFileSystemStore(t *testing.T) {
 		assertScoreEquals(t, got, want)
 	})
 
-	t.Run("store wins for existing players", func(t *testing.T) {
+	t.Run("store wins for new players", func(t *testing.T) {
 		database, cleanDatabase := createTempFile(t, `[
 			{"Name": "Cleo", "Wins": 10},
 			{"Name": "Chris", "Wins": 33}]`)

--- a/io/v7/FileSystemStore_test.go
+++ b/io/v7/FileSystemStore_test.go
@@ -76,7 +76,7 @@ func TestFileSystemStore(t *testing.T) {
 		assertScoreEquals(t, got, want)
 	})
 
-	t.Run("store wins for existing players", func(t *testing.T) {
+	t.Run("store wins for new players", func(t *testing.T) {
 		database, cleanDatabase := createTempFile(t, `[
 			{"Name": "Cleo", "Wins": 10},
 			{"Name": "Chris", "Wins": 33}]`)

--- a/io/v8/FileSystemStore_test.go
+++ b/io/v8/FileSystemStore_test.go
@@ -82,7 +82,7 @@ func TestFileSystemStore(t *testing.T) {
 		assertScoreEquals(t, got, want)
 	})
 
-	t.Run("store wins for existing players", func(t *testing.T) {
+	t.Run("store wins for new players", func(t *testing.T) {
 		database, cleanDatabase := createTempFile(t, `[
 			{"Name": "Cleo", "Wins": 10},
 			{"Name": "Chris", "Wins": 33}]`)

--- a/io/v9/FileSystemStore_test.go
+++ b/io/v9/FileSystemStore_test.go
@@ -82,7 +82,7 @@ func TestFileSystemStore(t *testing.T) {
 		assertScoreEquals(t, got, want)
 	})
 
-	t.Run("store wins for existing players", func(t *testing.T) {
+	t.Run("store wins for new players", func(t *testing.T) {
 		database, cleanDatabase := createTempFile(t, `[
 			{"Name": "Cleo", "Wins": 10},
 			{"Name": "Chris", "Wins": 33}]`)


### PR DESCRIPTION
The test names in the IO section regarding testing `.RecordWin(...)` for new players has the test name `store wins for existing players` but should be `store wins for new players`.