### PR TITLE
shorten CI build time, format .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,39 @@
 sudo: required
 language: go
+
 go:
-- 1.10.x
+  - 1.10.x
+
 install: true
+
 services:
-- docker
+  - docker
+
 stages:
-- build
-- spelling
-- epub
+  - build
+  - spelling
+  - epub
+
 jobs:
   include:
-  - stage: build
-    script:
-    - go get github.com/quii/learn-go-with-tests/command-line/v1
-    - go get -u golang.org/x/lint/golint
-    - "./build.sh"
-  - stage: spelling
-    script:
-    - go get -u github.com/client9/misspell/cmd/misspell
-    - misspell -error .
-  - stage: epub
-    script:
-    - docker pull jagregory/pandoc
-    - "./build.epub.sh"
-    deploy:
-      provider: releases
-      api_key:
-        secure: q58oofLU1tCcO618axSmlc3eOf6f/QtP/XORtn0o7z/1O6AENlWAIn0RYetHEp0JNYQfS4sqgy34gAy2H6BpZURaHc1muW0fhwRndBjrbU5DviflOc9lH8pLzDZpzhKdBiCMoZpDs+Gp27PmZn62vHSZkiR3EMdrJFoDV8/fUCy4UYs/U3/QiG/Qv/DnKM0GI5LfNWGtD0dzbe1z4qVEfUXk44CnxEJZoaSEx6e0zrP9QHreUGpADB4syzgSW/Q8RwmyZIWPZrmmBu8qzrmpJtcjNaUllx4VAIB86U5fZaUIEoAodGf7+3Ut8K5oI+eBo5HkAYShwrzXRs6gQWp8nwEWyxzEvLwf4949llnC0ez6qvSf7prXJKK2Rmvid7xZt51eMglBDatAFaprmdM4AZeWibUpVP2QbzYAqpkd8SZazmjYzRJPeduNzGoOOsHuqIWdmKHthQEMZXiXSDy4HWP9A085/+i45pK6jf1Bfu2XbCW+Yh3d1uTUCSStPMgVOLbTL8YGaKpnpO6TAo0/vAEiO4//lZeodx/w7s8zTDPVPpb9hDFbcwQfWZarPTzVQuUKrVagFlLooTpzJ2sU7I7Q45O6vvDvhZzj2gM+/gXtbS8CKwUNEOsJubprGksW5254vMRayTUVXXeHcrAIMcCdW0D9+YbXifmJvcc1LYk=
-      file: learn-go-with-tests.epub
-      skip_cleanup: true
-      on:
-        tags: true
+    - stage: build
+      script:
+        - go get github.com/quii/learn-go-with-tests/command-line/v1
+        - go get -u golang.org/x/lint/golint
+        - "./build.sh"
+    - stage: spelling
+      script:
+        - go get -u github.com/client9/misspell/cmd/misspell
+        - misspell -error .
+    - stage: epub
+      script:
+        - docker pull jagregory/pandoc
+        - "./build.epub.sh"
+      deploy:
+        provider: releases
+        api_key:
+          secure: q58oofLU1tCcO618axSmlc3eOf6f/QtP/XORtn0o7z/1O6AENlWAIn0RYetHEp0JNYQfS4sqgy34gAy2H6BpZURaHc1muW0fhwRndBjrbU5DviflOc9lH8pLzDZpzhKdBiCMoZpDs+Gp27PmZn62vHSZkiR3EMdrJFoDV8/fUCy4UYs/U3/QiG/Qv/DnKM0GI5LfNWGtD0dzbe1z4qVEfUXk44CnxEJZoaSEx6e0zrP9QHreUGpADB4syzgSW/Q8RwmyZIWPZrmmBu8qzrmpJtcjNaUllx4VAIB86U5fZaUIEoAodGf7+3Ut8K5oI+eBo5HkAYShwrzXRs6gQWp8nwEWyxzEvLwf4949llnC0ez6qvSf7prXJKK2Rmvid7xZt51eMglBDatAFaprmdM4AZeWibUpVP2QbzYAqpkd8SZazmjYzRJPeduNzGoOOsHuqIWdmKHthQEMZXiXSDy4HWP9A085/+i45pK6jf1Bfu2XbCW+Yh3d1uTUCSStPMgVOLbTL8YGaKpnpO6TAo0/vAEiO4//lZeodx/w7s8zTDPVPpb9hDFbcwQfWZarPTzVQuUKrVagFlLooTpzJ2sU7I7Q45O6vvDvhZzj2gM+/gXtbS8CKwUNEOsJubprGksW5254vMRayTUVXXeHcrAIMcCdW0D9+YbXifmJvcc1LYk=
+        file: learn-go-with-tests.epub
+        skip_cleanup: true
+        on:
+          tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ go:
 install: true
 services:
 - docker
-before_install:
-- docker pull jagregory/pandoc
 stages:
 - build
 - spelling
@@ -24,6 +22,7 @@ jobs:
     - misspell -error .
   - stage: epub
     script:
+    - docker pull jagregory/pandoc
     - "./build.epub.sh"
     deploy:
       provider: releases


### PR DESCRIPTION
Hi, @quii, we don't have to pull the pandoc docker image during every CI stage. So I made it pull when necessary. Also, I formatted the style of .travis.yml, I think it would be better to read and maintain. Plz take a look at this. Thanks!