### PR TITLE
time.md errata - ReadString invalid code reference

### DIFF
--- a/time.md
+++ b/time.md
@@ -275,7 +275,7 @@ func (cli *CLI) PlayPoker() {
 		blindTime = blindTime + 10*time.Minute
 	}
 
-	userInput, _ := cli.ReadString('\n')
+	userInput := cli.readLine()
 	cli.playerStore.RecordWin(extractWinner(userInput))
 }
 ```
@@ -289,7 +289,7 @@ We can encapsulate our scheduled alerts into a method just to make `PlayPoker` r
 ```go
 func (cli *CLI) PlayPoker() {
 	cli.scheduleBlindAlerts()
-	userInput, _ := cli.ReadString('\n')
+	userInput := cli.readLine()
 	cli.playerStore.RecordWin(extractWinner(userInput))
 }
 


### PR DESCRIPTION
It seems that `ReadString` should be `readLine` as there is no current
reference to `ReadString` in the code.

See https://github.com/quii/learn-go-with-tests/blob/79ac957d0e4357d542e0f09c4a1c38e263b87d8a/time/v1/CLI.go#L29