### PR TITLE
time.md - updating main code reference

### DIFF
--- a/time.md
+++ b/time.md
@@ -408,7 +408,7 @@ We then create the function `StdOutAlerter` which has the same signature as the 
 Update `main` where we create `NewCLI` to see this in action
 
 ```go
-game := poker.NewCLI(store, os.Stdin, poker.BlindAlerterFunc(poker.StdOutAlerter))
+poker.NewCLI(store, os.Stdin, poker.BlindAlerterFunc(poker.StdOutAlerter)).PlayPoker()
 ```
 
 Before running you might want to change the `blindTime` increment in `CLI` to be 10 seconds rather than 10 minutes just so you can see it in action.


### PR DESCRIPTION
The text says to update the code storing a `game` variable but we actually
need to call `PlayPoker()`. It seems the text would make more sense
listing the code needed to run the game.

See https://github.com/quii/learn-go-with-tests/blob/79ac957d0e4357d542e0f09c4a1c38e263b87d8a/time/v1/cmd/cli/main.go#L21