### PR TITLE
adding a link for the Github repo in gb-readme

### DIFF
--- a/gb-readme.md
+++ b/gb-readme.md
@@ -63,6 +63,6 @@ Taking my experience of learning with a group and my own personal way I am going
 
 ## Feedback
 
-* Add issues or [tweet me @quii](https://twitter.com/quii)
+* Add issues/submit PRs [here](https://github.com/quii/learn-go-with-tests) or [tweet me @quii](https://twitter.com/quii)
 
 [MIT license](LICENSE.md)


### PR DESCRIPTION
Adding a link for the Github repo so it's immediately clear where to go from website to contribute