### PR TITLE
Remove wrong header

### DIFF
--- a/reflection.md
+++ b/reflection.md
@@ -2,7 +2,7 @@
 
 [From Twitter](https://twitter.com/peterbourgon/status/1011403901419937792?s=09)
 
-> #golang challenge: write a function `walk(x interface{}, fn func(string))` which takes a struct `x` and calls `fn` for all strings fields found inside. difficulty level: recursively.
+> golang challenge: write a function `walk(x interface{}, fn func(string))` which takes a struct `x` and calls `fn` for all strings fields found inside. difficulty level: recursively.
 
 To do this we will need to use _reflection_.
 


### PR DESCRIPTION
When looking at the generated PDF I recognized, that the `golang challenge` quote had a hashtag which will be interpreted as a Header and so the ToC was wrong.