### PR TITLE
Updates Go installation instructions

### DIFF
--- a/install-go.md
+++ b/install-go.md
@@ -26,12 +26,6 @@ At this point you can now install Go:
 brew install go
 ```
 
-If you are going to deploy your programs to Linux based servers, you should enable cross compilation feature. If so, install using the following command:
-
-```sh
-brew install go --cross-compile-common
-```
-
 *You should follow any instructions recommended by your package manager. **Note** these may be host os specific*.
 
 You can verify the installation with:


### PR DESCRIPTION
The `--cross-compile-common` flag is no longer supported.
It was removed by the following commit: https://github.com/Homebrew/homebrew-core/commit/bd56fd444ce3d21b647558d8740f6aade9180cba