### PR TITLE
Updates mkdir to use $GOPATH

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -8,7 +8,7 @@ In the [previous chapter](install-go.md#go-environment) we discussed how Go is o
 
 Make a directory in the following path `$GOPATH/src/github.com/{your-user-id}/hello`.
 
-So if you're on a unix based OS and your username is "bob" and you are happy to stick with Go's conventions about `$GOPATH` (which is the easiest way of setting up) you could run `mkdir -p ~/go/src/github.com/bob/hello`.
+So if you're on a unix based OS and your username is "bob" and you are happy to stick with Go's conventions about `$GOPATH` (which is the easiest way of setting up) you could run `mkdir -p $GOPATH/src/github.com/bob/hello`.
 
 Create a file in this directory called `hello.go` and write this code. To run it type `go run hello.go`.
 


### PR DESCRIPTION
We can avoid a mistake by using `$GOPATH` instead of `~/go`, in case reader has set its path to be something else.