### PR TITLE
ln 475 - Added space before brackets

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -472,7 +472,7 @@ func TestSumAllTails(t *testing.T) {
 
     t.Run("safely sum empty slices", func(t *testing.T) {
         got := SumAllTails([]int{}, []int{3, 4, 5})
-        want :=[]int{0, 9}
+        want := []int{0, 9}
 
         if !reflect.DeepEqual(got, want) {
             t.Errorf("got %v want %v", got, want)


### PR DESCRIPTION
I realize `go fmt` will catch this, so prob a minor change. 