### PR TITLE
Fix Failing Test due to imprecise value of Pi

### DIFF
--- a/structs-methods-and-interfaces.md
+++ b/structs-methods-and-interfaces.md
@@ -166,7 +166,7 @@ func TestArea(t *testing.T) {
     t.Run("circles", func(t *testing.T) {
         circle := Circle{10}
         got := Area(circle)
-        want := 314.16
+        want := 314.1592653589793
 
         if got != want {
             t.Errorf("got %.2f want %.2f", got, want)


### PR DESCRIPTION
The [test](https://github.com/quii/learn-go-with-tests/blob/master/structs-methods-and-interfaces.md#write-the-test-first-1) for _circle_ area fails due to imprecise value of float64 Pi variable. This is already fixed in the solution code provided, but not reflected in the markdown documentation