### PR TITLE
close FileSystemStore file

### DIFF
--- a/command-line/v3/FileSystemStore.go
+++ b/command-line/v3/FileSystemStore.go
@@ -35,20 +35,24 @@ func NewFileSystemPlayerStore(file *os.File) (*FileSystemPlayerStore, error) {
 }
 
 // FileSystemPlayerStoreFromFile creates a PlayerStore from the contents of a JSON file found at path
-func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, error) {
+func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, func(), error) {
 	db, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem opening %s %v", path, err)
+		return nil, nil, fmt.Errorf("problem opening %s %v", path, err)
+	}
+
+	closeFunc := func() {
+		db.Close()
 	}
 
 	store, err := NewFileSystemPlayerStore(db)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem creating file system player store, %v ", err)
+		return nil, nil, fmt.Errorf("problem creating file system player store, %v ", err)
 	}
 
-	return store, nil
+	return store, closeFunc, nil
 }
 
 func initialisePlayerDBFile(file *os.File) error {

--- a/command-line/v3/cmd/cli/main.go
+++ b/command-line/v3/cmd/cli/main.go
@@ -2,19 +2,21 @@ package main
 
 import (
 	"fmt"
-	"github.com/quii/learn-go-with-tests/command-line/v3"
 	"log"
 	"os"
+
+	poker "github.com/quii/learn-go-with-tests/command-line/v3"
 )
 
 const dbFileName = "game.db.json"
 
 func main() {
-	store, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
+	store, close, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
 
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer close()
 
 	fmt.Println("Let's play poker")
 	fmt.Println("Type {Name} wins to record a win")

--- a/command-line/v3/cmd/webserver/main.go
+++ b/command-line/v3/cmd/webserver/main.go
@@ -1,19 +1,21 @@
 package main
 
 import (
-	"github.com/quii/learn-go-with-tests/command-line/v3"
 	"log"
 	"net/http"
+
+	poker "github.com/quii/learn-go-with-tests/command-line/v3"
 )
 
 const dbFileName = "game.db.json"
 
 func main() {
-	store, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
+	store, close, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
 
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer close()
 
 	server := poker.NewPlayerServer(store)
 

--- a/time/v1/FileSystemStore.go
+++ b/time/v1/FileSystemStore.go
@@ -35,20 +35,24 @@ func NewFileSystemPlayerStore(file *os.File) (*FileSystemPlayerStore, error) {
 }
 
 // FileSystemPlayerStoreFromFile creates a PlayerStore from the contents of a JSON file found at path
-func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, error) {
+func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, func(), error) {
 	db, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem opening %s %v", path, err)
+		return nil, nil, fmt.Errorf("problem opening %s %v", path, err)
+	}
+
+	closeFunc := func() {
+		db.Close()
 	}
 
 	store, err := NewFileSystemPlayerStore(db)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem creating file system player store, %v ", err)
+		return nil, nil, fmt.Errorf("problem creating file system player store, %v ", err)
 	}
 
-	return store, nil
+	return store, closeFunc, nil
 }
 
 func initialisePlayerDBFile(file *os.File) error {

--- a/time/v1/cmd/cli/main.go
+++ b/time/v1/cmd/cli/main.go
@@ -2,19 +2,21 @@ package main
 
 import (
 	"fmt"
-	"github.com/quii/learn-go-with-tests/time/v1"
 	"log"
 	"os"
+
+	poker "github.com/quii/learn-go-with-tests/time/v1"
 )
 
 const dbFileName = "game.db.json"
 
 func main() {
-	store, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
+	store, close, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
 
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer close()
 
 	fmt.Println("Let's play poker")
 	fmt.Println("Type {Name} wins to record a win")

--- a/time/v2/FileSystemStore.go
+++ b/time/v2/FileSystemStore.go
@@ -35,20 +35,24 @@ func NewFileSystemPlayerStore(file *os.File) (*FileSystemPlayerStore, error) {
 }
 
 // FileSystemPlayerStoreFromFile creates a PlayerStore from the contents of a JSON file found at path
-func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, error) {
+func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, func(), error) {
 	db, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem opening %s %v", path, err)
+		return nil, nil, fmt.Errorf("problem opening %s %v", path, err)
+	}
+
+	closeFunc := func() {
+		db.Close()
 	}
 
 	store, err := NewFileSystemPlayerStore(db)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem creating file system player store, %v ", err)
+		return nil, nil, fmt.Errorf("problem creating file system player store, %v ", err)
 	}
 
-	return store, nil
+	return store, closeFunc, nil
 }
 
 func initialisePlayerDBFile(file *os.File) error {

--- a/time/v2/cmd/cli/main.go
+++ b/time/v2/cmd/cli/main.go
@@ -2,19 +2,21 @@ package main
 
 import (
 	"fmt"
-	"github.com/quii/learn-go-with-tests/time/v2"
 	"log"
 	"os"
+
+	poker "github.com/quii/learn-go-with-tests/time/v2"
 )
 
 const dbFileName = "game.db.json"
 
 func main() {
-	store, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
+	store, close, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
 
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer close()
 
 	game := poker.NewTexasHoldem(poker.BlindAlerterFunc(poker.StdOutAlerter), store)
 	cli := poker.NewCLI(os.Stdin, os.Stdout, game)

--- a/time/v3/FileSystemStore.go
+++ b/time/v3/FileSystemStore.go
@@ -35,20 +35,24 @@ func NewFileSystemPlayerStore(file *os.File) (*FileSystemPlayerStore, error) {
 }
 
 // FileSystemPlayerStoreFromFile creates a PlayerStore from the contents of a JSON file found at path
-func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, error) {
+func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, func(), error) {
 	db, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem opening %s %v", path, err)
+		return nil, nil, fmt.Errorf("problem opening %s %v", path, err)
+	}
+
+	closeFunc := func() {
+		db.Close()
 	}
 
 	store, err := NewFileSystemPlayerStore(db)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem creating file system player store, %v ", err)
+		return nil, nil, fmt.Errorf("problem creating file system player store, %v ", err)
 	}
 
-	return store, nil
+	return store, closeFunc, nil
 }
 
 func initialisePlayerDBFile(file *os.File) error {

--- a/time/v3/cmd/cli/main.go
+++ b/time/v3/cmd/cli/main.go
@@ -2,19 +2,21 @@ package main
 
 import (
 	"fmt"
-	"github.com/quii/learn-go-with-tests/time/v3"
 	"log"
 	"os"
+
+	poker "github.com/quii/learn-go-with-tests/time/v3"
 )
 
 const dbFileName = "game.db.json"
 
 func main() {
-	store, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
+	store, close, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
 
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer close()
 
 	game := poker.NewTexasHoldem(poker.BlindAlerterFunc(poker.StdOutAlerter), store)
 	cli := poker.NewCLI(os.Stdin, os.Stdout, game)

--- a/websockets/v1/FileSystemStore.go
+++ b/websockets/v1/FileSystemStore.go
@@ -35,20 +35,24 @@ func NewFileSystemPlayerStore(file *os.File) (*FileSystemPlayerStore, error) {
 }
 
 // FileSystemPlayerStoreFromFile creates a PlayerStore from the contents of a JSON file found at path
-func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, error) {
+func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, func(), error) {
 	db, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem opening %s %v", path, err)
+		return nil, nil, fmt.Errorf("problem opening %s %v", path, err)
+	}
+
+	closeFunc := func() {
+		db.Close()
 	}
 
 	store, err := NewFileSystemPlayerStore(db)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem creating file system player store, %v ", err)
+		return nil, nil, fmt.Errorf("problem creating file system player store, %v ", err)
 	}
 
-	return store, nil
+	return store, closeFunc, nil
 }
 
 func initialisePlayerDBFile(file *os.File) error {

--- a/websockets/v1/cmd/cli/main.go
+++ b/websockets/v1/cmd/cli/main.go
@@ -2,19 +2,21 @@ package main
 
 import (
 	"fmt"
-	"github.com/quii/learn-go-with-tests/websockets/v1"
 	"log"
 	"os"
+
+	poker "github.com/quii/learn-go-with-tests/websockets/v1"
 )
 
 const dbFileName = "game.db.json"
 
 func main() {
-	store, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
+	store, close, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
 
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer close()
 
 	game := poker.NewTexasHoldem(poker.BlindAlerterFunc(poker.StdOutAlerter), store)
 	cli := poker.NewCLI(os.Stdin, os.Stdout, game)

--- a/websockets/v2/FileSystemStore.go
+++ b/websockets/v2/FileSystemStore.go
@@ -35,20 +35,24 @@ func NewFileSystemPlayerStore(file *os.File) (*FileSystemPlayerStore, error) {
 }
 
 // FileSystemPlayerStoreFromFile creates a PlayerStore from the contents of a JSON file found at path
-func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, error) {
+func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, func(), error) {
 	db, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem opening %s %v", path, err)
+		return nil, nil, fmt.Errorf("problem opening %s %v", path, err)
+	}
+
+	closeFunc := func() {
+		db.Close()
 	}
 
 	store, err := NewFileSystemPlayerStore(db)
 
 	if err != nil {
-		return nil, fmt.Errorf("problem creating file system player store, %v ", err)
+		return nil, nil, fmt.Errorf("problem creating file system player store, %v ", err)
 	}
 
-	return store, nil
+	return store, closeFunc, nil
 }
 
 func initialisePlayerDBFile(file *os.File) error {

--- a/websockets/v2/cmd/cli/main.go
+++ b/websockets/v2/cmd/cli/main.go
@@ -2,19 +2,21 @@ package main
 
 import (
 	"fmt"
-	"github.com/quii/learn-go-with-tests/websockets/v2"
 	"log"
 	"os"
+
+	poker "github.com/quii/learn-go-with-tests/websockets/v2"
 )
 
 const dbFileName = "game.db.json"
 
 func main() {
-	store, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
+	store, close, err := poker.FileSystemPlayerStoreFromFile(dbFileName)
 
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer close()
 
 	game := poker.NewTexasHoldem(poker.BlindAlerterFunc(poker.Alerter), store)
 	cli := poker.NewCLI(os.Stdin, os.Stdout, game)


### PR DESCRIPTION
I noticed that `FileSystemStore` files were not being properly closed
I updated `FileSystemPlayerStoreFromFile` so that it returns a function that we can call to close the file it opened for us
