### PR TITLE
Inconsistency in code snippet in Arrays example

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -283,7 +283,7 @@ We need to define SumAll according to what our test wants.
 Go can let you write [_variadic functions_](https://gobyexample.com/variadic-functions) that can take a variable number of arguments.
 
 ```go
-func SumAll(numbersToSum ...[]int) (sums []int) {
+func SumAll(numbersToSum ...[]int) []int {
     return
 }
 ```


### PR DESCRIPTION
Noticed inconsistency in one of the code snippet functions. It uses a named return, but later examples don't use a named return. This makes the implementation code fail if you still have the named return.