### PR TITLE
fix CI for forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ go:
   - 1.10.x
   - 1.11.x
 
+before_install:
+  - go get github.com/quii/learn-go-with-tests/command-line/v1
+
 install: true
 
 services:
@@ -19,7 +22,6 @@ jobs:
   include:
     - stage: build
       script:
-        - go get github.com/quii/learn-go-with-tests/command-line/v1
         - go get -u golang.org/x/lint/golint
         - "./build.sh"
     - stage: spelling


### PR DESCRIPTION
As an upstream, this repo depends on itself, but for a fork, it depends
on this repo. In Travis CI, `install: true` skipps `go get` for Go
projects, so the forks won't get the dependence and will cause the
CI failure. This is fixed by installing dependence in `before_install`.

Ref: https://docs.travis-ci.com/user/job-lifecycle/#skipping-the-installation-phase