### PR TITLE
fix: avoid goroutine leak

### DIFF
--- a/select/v2/racer.go
+++ b/select/v2/racer.go
@@ -18,7 +18,7 @@ func ping(url string) chan bool {
 	ch := make(chan bool)
 	go func() {
 		http.Get(url)
-		ch <- true
+		close(ch)
 	}()
 	return ch
 }

--- a/select/v3/racer.go
+++ b/select/v3/racer.go
@@ -29,7 +29,7 @@ func ping(url string) chan bool {
 	ch := make(chan bool)
 	go func() {
 		http.Get(url)
-		ch <- true
+		close(ch)
 	}()
 	return ch
 }


### PR DESCRIPTION
Hello, when i read your graceful book *learn go with tests*, i found 
some issue in `select` chapter which will lead to goroutine leak.

If nobody receive from `ch`, this goroutine will always block, 
to avoid goroutine leak, we can make a buffered channel, like
`ch := make(chan bool, 1)` or just `close` it.

Also, i suggest use `done = make(chan struct{})`which more idiomatic in go
to substitute `ch := make(chan bool)` in this situation, thanks.