### PR TITLE
Remove uncompilable if block from code example

### DIFF
--- a/context.md
+++ b/context.md
@@ -358,10 +358,6 @@ t.Run("returns data from store", func(t *testing.T) {
     if response.Body.String() != data {
         t.Errorf(`got "%s", want "%s"`, response.Body.String(), data)
     }
-
-    if store.ctx != request.Context() {
-        t.Errorf("store was not passed through a context %v", store.ctx)
-    }
 })
 ```
 


### PR DESCRIPTION
In the context exercise we update SpyStore to remove the cancel from the spy and just pass the context into the fetch. In one of the if statements of the happy path we reference store.ctx. 
Just removed the if statement to make the test actually run and pass like the instructions say. 