### PR TITLE
Capitalize French in arguments to Hello function

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -515,6 +515,6 @@ By now you should have some understanding of:
 * Writing the smallest amount of code to make it pass so we know we have working software
 * _Then_ refactor, backed with the safety of our tests to ensure we have well-crafted code that is easy to work with
 
-In our case we've gone from `Hello()` to `Hello("name")`, to `Hello("name", "french")` in small, easy to understand steps.
+In our case we've gone from `Hello()` to `Hello("name")`, to `Hello("name", "French")` in small, easy to understand steps.
 
 This is of course trivial compared to "real world" software but the principles still stand. TDD is a skill that needs practice to develop but by being able to break problems down into smaller components that you can test you will have a much easier time writing software.


### PR DESCRIPTION
In the section introducing the French version of greeting prefix for the Hello World exercise, we use `"French"` but in the final overview section, it's written as `"french"`. This is a minor thing but I wanted to make sure the examples are consistent.