### PR TITLE
The countdown's work divide was unclear

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -30,7 +30,7 @@ We dont want to spend a long time with code that will theoretically work after s
 Here's how we can divide our work up and iterate on it:
 
 - Print 3
-- Print 3 to Go!
+- Print 1, 2, 3 and Go!
 - Wait a second between each line
 
 ## Write the test first


### PR DESCRIPTION
Basically it read 'Print 3 to Go' and 'Print 1 to Go' was meant.

However, the current version is more clear IMHO.