### PR TITLE
modify the godoc flag when lauching the docs locally

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -102,7 +102,7 @@ We will later explore the difference between methods and functions.
 
 ### Go doc
 
-Another quality of life feature of Go is the documentation. You can launch the docs locally by running `godoc -http :8000`. If you go to [localhost:8000/pkg](http://localhost:8000/pkg) you will see all the packages installed on your system.
+Another quality of life feature of Go is the documentation. You can launch the docs locally by running `godoc -http=localhost:8000`. If you go to [localhost:8000/pkg](http://localhost:8000/pkg) you will see all the packages installed on your system.
 
 The vast majority of the standard library has excellent documentation with examples. Navigating to [http://localhost:8000/pkg/testing/](http://localhost:8000/pkg/testing/) would be worthwhile to see what's available to you.
 


### PR DESCRIPTION
replace the flag `-http:8000` with `-http=localhost:8000` . 
P.S. I tried the former (on mac) but got an error which said "flag provided but not defined: -http:8000", so I changed to the latter and could view the doc locally via localhost:8000. 