### PR TITLE
Making store/svr creation in a standard way

### DIFF
--- a/context.md
+++ b/context.md
@@ -149,7 +149,7 @@ We'll need to update our happy path test to assert that it does not get cancelle
 
 ```go
 t.Run("returns data from store", func(t *testing.T) {
-    store := SpyStore{response: data}
+    store := &SpyStore{response: data}
     svr := Server(store)
 
     request := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/context.md
+++ b/context.md
@@ -150,7 +150,7 @@ We'll need to update our happy path test to assert that it does not get cancelle
 ```go
 t.Run("returns data from store", func(t *testing.T) {
     store := SpyStore{response: data}
-    svr := Server(&store)
+    svr := Server(store)
 
     request := httptest.NewRequest(http.MethodGet, "/", nil)
     response := httptest.NewRecorder()


### PR DESCRIPTION
We first create store in the following way:
`store := &SpyStore{response: data}`
and svr:
`svr := Server(store)`

Later, on lines 152 & 153:
`store := SpyStore{response: data}`
`svr := Server(&store)`

And from this point on, and defined in the files stored in the context folder in this repo:
`store := &SpyStore{response: data, t: t}`
`svr := Server(store)`

I believe for new members of this community trying to learn Go, it is best to keep it standard so people don't get confused, or change their code for unnecessary reasons.

My proposed change is to keep it in this way:

`store := &SpyStore{response: data}`
`svr := Server(store)`