### PR TITLE
Add godoc note for 1.13 in hello world chapter

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -108,6 +108,8 @@ Another quality of life feature of Go is the documentation. You can launch the d
 
 The vast majority of the standard library has excellent documentation with examples. Navigating to [http://localhost:8000/pkg/testing/](http://localhost:8000/pkg/testing/) would be worthwhile to see what's available to you.
 
+If you don't have `godoc` command, then maybe you are using the newer version of Go (1.13 or later) which is [no longer including `godoc`](https://golang.org/doc/go1.13#godoc). You can manually install it with `go get golang.org/x/tools/cmd/godoc`.
+
 ### Hello, YOU
 
 Now that we have a test we can iterate on our software safely.


### PR DESCRIPTION
This helps one who has installed Go 1.1.3 which is no longer including `godoc` command. See #248 