### PR TITLE
Mentioning Modules in the "Install Go" chapter

### DIFF
--- a/install-go.md
+++ b/install-go.md
@@ -37,6 +37,7 @@ go version go1.10 darwin/amd64
 
 ## Go Environment
 
+### $GOPATH
 Go is opinionated.
 
 By convention, all Go code lives within a single workspace (folder). This workspace could be anywhere in your machine. If you don't specify, Go will assume $HOME/go as the default workspace. The workspace is identified (and modified) by the environment variable [GOPATH](https://golang.org/cmd/go/#hdr-GOPATH_environment_variable).
@@ -61,6 +62,24 @@ mkdir -p $GOPATH/src $GOPATH/pkg $GOPATH/bin
 ```
 
 At this point you can _go get_ and the src/package/bin will be installed correctly in the appropriate $GOPATH/xxx directory.
+
+### Go Modules
+Go 1.11 introduced [Modules](https://github.com/golang/go/wiki/Modules), enabling an alternative workflow. This new approach will gradually [become the default](https://blog.golang.org/modules2019) mode, deprecating the use of GOPATH.
+
+Modules aim to solve problems related to dependency management, version selection and reproducible builds; they also enable users to run Go code outside of GOPATH.
+
+Using Modules is prety straightforward. Just select any directory outside GOPATH as the root of your project, and create a new module with the go mod init command.
+```sh
+mkdir my-project
+cd my-project
+go mod init <modulename>
+```
+
+The built-in documentation provides an overview of all available go mod commands.
+```sh
+go help mod
+go help mod init
+```
 
 ## Go Editor
 

--- a/install-go.md
+++ b/install-go.md
@@ -68,7 +68,7 @@ Go 1.11 introduced [Modules](https://github.com/golang/go/wiki/Modules), enablin
 
 Modules aim to solve problems related to dependency management, version selection and reproducible builds; they also enable users to run Go code outside of GOPATH.
 
-Using Modules is prety straightforward. Just select any directory outside GOPATH as the root of your project, and create a new module with the go mod init command.
+Using Modules is pretty straightforward. Just select any directory outside GOPATH as the root of your project, and create a new module with the go mod init command.
 ```sh
 mkdir my-project
 cd my-project

--- a/install-go.md
+++ b/install-go.md
@@ -68,14 +68,34 @@ Go 1.11 introduced [Modules](https://github.com/golang/go/wiki/Modules), enablin
 
 Modules aim to solve problems related to dependency management, version selection and reproducible builds; they also enable users to run Go code outside of GOPATH.
 
-Using Modules is pretty straightforward. Just select any directory outside GOPATH as the root of your project, and create a new module with the go mod init command.
+Using Modules is pretty straightforward. Select any directory outside GOPATH as the root of your project, and create a new module with the go mod init command.
+
+A go.mod file will be generated, containing the module path, a Go version, and its dependency requirements, which are the other modules needed for a successful build.
+
+If no <modulepath> is specified, go mod init will try to guess the module path from the directory structure, but it can also be overrided, by supplying an argument.
+
 ```sh
 mkdir my-project
 cd my-project
-go mod init <modulename>
+go mod init <modulepath>
+```
+
+A go.mod file could look like this
+
+```
+module cmd
+
+go 1.12
+
+require (
+        github.com/google/pprof v0.0.0-20190515194954-54271f7e092f
+        golang.org/x/arch v0.0.0-20190815191158-8a70ba74b3a1
+        golang.org/x/tools v0.0.0-20190611154301-25a4f137592f
+)
 ```
 
 The built-in documentation provides an overview of all available go mod commands.
+
 ```sh
 go help mod
 go help mod init


### PR DESCRIPTION
I drafted a paragraph that mentions the usage of Go Modules and how someone can use them to work and run code outside of GOPATH. 

I think it's worth mentioning, since it will gradually become the 'proposed' way of working with Go projects, and it makes life easier. `go mod init` will create a couple of files, `go.mod` and `go.sum`, which hold information about packages and version requirements; I don't know if it should be mentioned as well.

Any comments on the writing style, the tone, or anything else are welcome.

Thanks!

Fixes : https://github.com/quii/learn-go-with-tests/issues/252