### PR TITLE
Math: SVG struct Width and Height

### DIFF
--- a/math.md
+++ b/math.md
@@ -1118,8 +1118,8 @@ tests, to sharpen everything up.
 type SVG struct {
 	XMLName xml.Name `xml:"svg"`
 	Xmlns   string   `xml:"xmlns,attr"`
-	Width   float64  `xml:"width,attr"`
-	Height  float64  `xml:"height,attr"`
+	Width   string   `xml:"width,attr"`
+	Height  string   `xml:"height,attr"`
 	ViewBox string   `xml:"viewBox,attr"`
 	Version string   `xml:"version,attr"`
 	Circle  Circle   `xml:"circle"`


### PR DESCRIPTION
We can't turn Width and Height to float64 because in xml string there are values with '%' character and the test fails.