### PR TITLE
Update integers.md to reference %q

### DIFF
--- a/integers.md
+++ b/integers.md
@@ -23,7 +23,7 @@ func TestAdder(t *testing.T) {
 }
 ```
 
-You will notice that we're using `%d` as our format strings rather than `%s`. That's because we want it to print an integer rather than a string.
+You will notice that we're using `%d` as our format strings rather than `%q`. That's because we want it to print an integer rather than a string.
 
 Also note that we are no longer using the main package, instead we've defined a package named integers, as the name suggests this will group functions for working with integers such as Add.
 


### PR DESCRIPTION
The [hello-world.md](https://github.com/quii/learn-go-with-tests/blob/master/hello-world.md) file uses %q but then the next lecture [integers.md](https://github.com/quii/learn-go-with-tests/blob/master/iteration.md) references %s.

This pull request updates it to %q to be consistent with the first lecture.