### PR TITLE
Fix formatting issue on sync.md

### DIFF
--- a/sync.md
+++ b/sync.md
@@ -126,7 +126,7 @@ t.Run("it runs safely concurrently", func(t *testing.T) {
     var wg sync.WaitGroup
     wg.Add(wantedCount)
 
-    for i:=0; i<wantedCount; i++ {
+    for i := 0; i < wantedCount; i++ {
         go func(w *sync.WaitGroup) {
             counter.Inc()
             w.Done()


### PR DESCRIPTION
There was a section of sync.md that was different from what go fmt would
output. This has been fixed.

Fixes #302