### PR TITLE
fix the wrong use of RWMutex in http-server/v5

### DIFF
--- a/http-server/v5/InMemoryPlayerStore.go
+++ b/http-server/v5/InMemoryPlayerStore.go
@@ -19,14 +19,14 @@ type InMemoryPlayerStore struct {
 
 // RecordWin will record a player's win
 func (i *InMemoryPlayerStore) RecordWin(name string) {
-	i.lock.RLock()
-	defer i.lock.RUnlock()
+	i.lock.Lock()
+	defer i.lock.Unlock()
 	i.store[name]++
 }
 
 // GetPlayerScore retrieves scores for a given player
 func (i *InMemoryPlayerStore) GetPlayerScore(name string) int {
-	i.lock.Lock()
-	defer i.lock.Unlock()
+	i.lock.RLock()
+	defer i.lock.RUnlock()
 	return i.store[name]
 }


### PR DESCRIPTION
Hi!

Thank you for your amazing book! I have learned a lot from it.

When I read the code in http-server/v5, I found the use of RWMutex was wrong. In the method `RecordWin()`，we need to modify the value of the store, so it should be unsafe in concurrency and use a write lock.  In the method `GetPlayerScore()`，we just read the data, so we can use a read lock. The situation was also mentioned in #297. I have fixed it now.