### PR TITLE
fix formatting on modulepath to render it visible

### DIFF
--- a/install-go.md
+++ b/install-go.md
@@ -72,7 +72,7 @@ Using Modules is pretty straightforward. Select any directory outside GOPATH as 
 
 A go.mod file will be generated, containing the module path, a Go version, and its dependency requirements, which are the other modules needed for a successful build.
 
-If no <modulepath> is specified, go mod init will try to guess the module path from the directory structure, but it can also be overrided, by supplying an argument.
+If no &lt;modulepath&gt; is specified, go mod init will try to guess the module path from the directory structure, but it can also be overrided, by supplying an argument.
 
 ```sh
 mkdir my-project


### PR DESCRIPTION
`<modulepath>`'s less-than/greater-than carets were getting rendered as an HTML tag, rendering them invisible in the final Markdown. This replaces them with the standard HTML. Happy to shift to backticks or another solution if preferred!

This is a documentation fix and shouldn't affect anything else.