### PR TITLE
Fix: godoc.org was replaced with pkg.go.dev

### DIFF
--- a/integers.md
+++ b/integers.md
@@ -140,7 +140,7 @@ To try this out, run `godoc -http=:6060` and navigate to `http://localhost:6060/
 
 Inside here you'll see a list of all the packages in your `$GOPATH`, so assuming you wrote this code in somewhere like `$GOPATH/src/github.com/{your_id}` you'll be able to find your example documentation.
 
-If you publish your code with examples to a public URL, you can share the documentation of your code at [godoc.org](https://godoc.org). For example, here is the finalised API for this chapter [https://godoc.org/github.com/quii/learn-go-with-tests/integers/v2](https://godoc.org/github.com/quii/learn-go-with-tests/integers/v2).
+If you publish your code with examples to a public URL, you can share the documentation of your code at [pkg.go.dev](https://pkg.go.dev/). For example, [here](https://pkg.go.dev/github.com/quii/learn-go-with-tests/integers/v2) is the finalised API for this chapter. This web interface allows you to search for documentation of standard library packages and third-party packages.
 
 ## Wrapping up
 


### PR DESCRIPTION
Addresses issue #346 

- Replaced godoc.org by pkg.go.dev to be up to date with recent changes in terms of package documentation
- Added a brief description of what you can do thanks to this web interface