### PR TITLE
fix Manny Lehman link on gitbook.io

### DIFF
--- a/why.md
+++ b/why.md
@@ -22,7 +22,7 @@ A lot of people are choosing Go to build systems because it has made a number of
 
 Even with all these great properties we can still make terrible systems, so we should look to the past and understand lessons in software engineering that apply no matter how shiny (or not) your language is.
 
-In 1974 a clever software engineer called [Manny Lehman](https://en.wikipedia.org/wiki/Manny_Lehman_(computer_scientist)) wrote [Lehman's laws of software evolution](https://en.wikipedia.org/wiki/Lehman%27s_laws_of_software_evolution).
+In 1974 a clever software engineer called [Manny Lehman](https://en.wikipedia.org/wiki/Manny_Lehman_%28computer_scientist%29) wrote [Lehman's laws of software evolution](https://en.wikipedia.org/wiki/Lehman%27s_laws_of_software_evolution).
 
 > The laws describe a balance between forces driving new developments on one hand, and forces that slow down progress on the other hand.
 


### PR DESCRIPTION
The renderer on https://quii.gitbook.io/learn-go-with-tests/meta/why cannot handle `))`
unlike Github's renderer.

Thus currently the https://quii.gitbook.io/learn-go-with-tests/meta/why looks broken.