### PR TITLE
Update reflection.md

### DIFF
--- a/reflection.md
+++ b/reflection.md
@@ -818,23 +818,27 @@ We can iterate through all values sent through channel until it was closed with 
 func walk(x interface{}, fn func(input string)) {
 	val := getValue(x)
 
-	var getField func(int) reflect.Value
+	walkValue := func(value reflect.Value) {
+		walk(value.Interface(), fn)
+	}
 
 	switch val.Kind() {
 	case reflect.String:
 		fn(val.String())
 	case reflect.Struct:
-		numberOfValues = val.NumField()
-		getField = val.Field
+		for i := 0; i < val.NumField(); i++ {
+			walkValue(val.Field(i))
+		}
 	case reflect.Slice, reflect.Array:
-		numberOfValues = val.Len()
-		getField = val.Index
+		for i := 0; i < val.Len(); i++ {
+			walkValue(val.Index(i))
+		}
 	case reflect.Map:
 		for _, key := range val.MapKeys() {
-			walk(val.MapIndex(key).Interface(), fn)
+			walkValue(val.MapIndex(key))
 		}
 	case reflect.Chan:
-		for v, ok := val.Recv(); ok; v, ok = val.Recv() {	
+		for v, ok := val.Recv(); ok; v, ok = val.Recv() {
 			walk(v.Interface(), fn)
 		}
 	}
@@ -879,23 +883,27 @@ Non zero-argument functions do not seem to make a lot of sense in this scenario.
 func walk(x interface{}, fn func(input string)) {
 	val := getValue(x)
 
-	var getField func(int) reflect.Value
+	walkValue := func(value reflect.Value) {
+		walk(value.Interface(), fn)
+	}
 
 	switch val.Kind() {
 	case reflect.String:
 		fn(val.String())
 	case reflect.Struct:
-		numberOfValues = val.NumField()
-		getField = val.Field
+		for i := 0; i < val.NumField(); i++ {
+			walkValue(val.Field(i))
+		}
 	case reflect.Slice, reflect.Array:
-		numberOfValues = val.Len()
-		getField = val.Index
+		for i := 0; i < val.Len(); i++ {
+			walkValue(val.Index(i))
+		}
 	case reflect.Map:
 		for _, key := range val.MapKeys() {
-			walk(val.MapIndex(key).Interface(), fn)
+			walkValue(val.MapIndex(key))
 		}
 	case reflect.Chan:
-		for v, ok := val.Recv(); ok; v, ok = val.Recv() {	
+		for v, ok := val.Recv(); ok; v, ok = val.Recv() {
 			walk(v.Interface(), fn)
 		}
 	case reflect.Func:


### PR DESCRIPTION
The examples after the introduction of `walkValue` are still using the `numberOfValues` and `getField` variables.