### PR TITLE
Inconsistency in usage of the startingBalance variable in pointers-and-errors.md

### DIFF
--- a/pointers-and-errors.md
+++ b/pointers-and-errors.md
@@ -432,10 +432,11 @@ And in our test
 
 ```go
 t.Run("Withdraw insufficient funds", func(t *testing.T) {
-    wallet := Wallet{Bitcoin(20)}
+    startingBalance := Bitcoin(20)
+    wallet := Wallet{startingBalance}
     err := wallet.Withdraw(Bitcoin(100))
 
-    assertBalance(t, wallet, Bitcoin(20))
+    assertBalance(t, wallet, startingBalance)
     assertError(t, err)
 })
 ```


### PR DESCRIPTION
You've been using the startingBalance variable in the code examples and it feels inconsistent to stop using it in the middle.

So it goes in the following order:
```
t.Run("Withdraw insufficient funds", func(t *testing.T) {
    startingBalance := Bitcoin(20)
    wallet := Wallet{startingBalance}
    err := wallet.Withdraw(Bitcoin(100))

    assertBalance(t, wallet, startingBalance)

    if err == nil {
        t.Error("wanted an error but didn't get one")
    }
})
```

Then:
```
t.Run("Withdraw insufficient funds", func(t *testing.T) {
    wallet := Wallet{Bitcoin(20)}
    err := wallet.Withdraw(Bitcoin(100))

    assertBalance(t, wallet, Bitcoin(20))
    assertError(t, err)
})
```

And then again:
```
t.Run("Withdraw insufficient funds", func(t *testing.T) {
    startingBalance := Bitcoin(20)
    wallet := Wallet{startingBalance}
    err := wallet.Withdraw(Bitcoin(100))

    assertBalance(t, wallet, startingBalance)
    assertError(t, err, "cannot withdraw, insufficient funds")
})
```

