### PR TITLE
return [] instead of null when request /league

### DIFF
--- a/json.md
+++ b/json.md
@@ -737,7 +737,7 @@ func TestRecordingWinsAndRetrievingThem(t *testing.T) {
 
 ```go
 func (i *InMemoryPlayerStore) GetLeague() []Player {
-	var league []Player
+	league := make([]Player, 0, 1024)
 	for name, wins := range i.store {
 		league = append(league, Player{name, wins})
 	}


### PR DESCRIPTION
Maybe it should return `[]` instead of `null` when the `Content-Type` is `application/json` in my opinion.