### PR TITLE
Reword test block to better match assertion

### DIFF
--- a/select.md
+++ b/select.md
@@ -396,7 +396,7 @@ func TestRacer(t *testing.T) {
 		}
 	})
 
-	t.Run("returns an error if a server doesn't respond within 10s", func(t *testing.T) {
+	t.Run("returns an error if a server doesn't respond within the specified time", func(t *testing.T) {
 		server := makeDelayedServer(25 * time.Millisecond)
 
 		defer server.Close()


### PR DESCRIPTION
Hi all,

I've been following this repo to help teach myself go and it's been a great help.
I noticed on line 399 the first argument in t.Run doesn't match the assertion. Raising this PR for your consideration as to whether you think this wording fits better or not.