### PR TITLE
switched to using TB for helpers

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -503,7 +503,7 @@ Our tests have some repeated code around assertion again, let's extract that int
 ```go
 func TestSumAllTails(t *testing.T) {
 
-	checkSums := func(t *testing.T, got, want []int) {
+	checkSums := func(t testing.TB, got, want []int) {
 		t.Helper()
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v want %v", got, want)

--- a/command-line.md
+++ b/command-line.md
@@ -261,7 +261,7 @@ The test passes. We'll add another test to force us to write some real code next
 In `server_test` we earlier did checks to see if wins are recorded as we have here. Let's DRY that assertion up into a helper
 
 ```go
-func assertPlayerWin(t *testing.T, store *StubPlayerStore, winner string) {
+func assertPlayerWin(t testing.TB, store *StubPlayerStore, winner string) {
 	t.Helper()
 
 	if len(store.winCalls) != 1 {
@@ -472,7 +472,7 @@ func (s *StubPlayerStore) GetLeague() League {
 	return s.league
 }
 
-func AssertPlayerWin(t *testing.T, store *StubPlayerStore, winner string) {
+func AssertPlayerWin(t testing.TB, store *StubPlayerStore, winner string) {
 	t.Helper()
 
 	if len(store.winCalls) != 1 {

--- a/command-line/v1/file_system_store_test.go
+++ b/command-line/v1/file_system_store_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (*os.File, func()) {
+func createTempFile(t testing.TB, initialData string) (*os.File, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -109,14 +109,14 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)
 	}
 }
 
-func assertNoError(t *testing.T, err error) {
+func assertNoError(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("didn't expect an error but got one, %v", err)

--- a/command-line/v1/server_test.go
+++ b/command-line/v1/server_test.go
@@ -123,14 +123,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -141,14 +141,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -170,7 +170,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/command-line/v2/file_system_store_test.go
+++ b/command-line/v2/file_system_store_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (*os.File, func()) {
+func createTempFile(t testing.TB, initialData string) (*os.File, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -109,14 +109,14 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)
 	}
 }
 
-func assertNoError(t *testing.T, err error) {
+func assertNoError(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("didn't expect an error but got one, %v", err)

--- a/command-line/v2/server_test.go
+++ b/command-line/v2/server_test.go
@@ -123,14 +123,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -141,14 +141,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -170,7 +170,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/command-line/v3/file_system_store_test.go
+++ b/command-line/v3/file_system_store_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (*os.File, func()) {
+func createTempFile(t testing.TB, initialData string) (*os.File, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -109,14 +109,14 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)
 	}
 }
 
-func assertNoError(t *testing.T, err error) {
+func assertNoError(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("didn't expect an error but got one, %v", err)

--- a/command-line/v3/server_test.go
+++ b/command-line/v3/server_test.go
@@ -97,14 +97,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -115,14 +115,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -144,7 +144,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/command-line/v3/testing.go
+++ b/command-line/v3/testing.go
@@ -26,7 +26,7 @@ func (s *StubPlayerStore) GetLeague() League {
 }
 
 // AssertPlayerWin allows you to spy on the store's calls to RecordWin.
-func AssertPlayerWin(t *testing.T, store *StubPlayerStore, winner string) {
+func AssertPlayerWin(t testing.TB, store *StubPlayerStore, winner string) {
 	t.Helper()
 
 	if len(store.WinCalls) != 1 {

--- a/context-aware-reader.md
+++ b/context-aware-reader.md
@@ -75,7 +75,7 @@ func TestContextAwareReader(t *testing.T) {
 	})
 }
 
-func assertBufferHas(t *testing.T, buf []byte, want string) {
+func assertBufferHas(t testing.TB, buf []byte, want string) {
 	t.Helper()
 	got := string(buf)
 	if got != want {

--- a/hello-world.md
+++ b/hello-world.md
@@ -260,7 +260,7 @@ We can and should refactor our tests.
 ```go
 func TestHello(t *testing.T) {
 
-	assertCorrectMessage := func(t *testing.T, got, want string) {
+	assertCorrectMessage := func(t testing.TB, got, want string) {
 		t.Helper()
 		if got != want {
 			t.Errorf("got %q want %q", got, want)
@@ -285,6 +285,8 @@ func TestHello(t *testing.T) {
 What have we done here?
 
 We've refactored our assertion into a function. This reduces duplication and improves readability of our tests. In Go you can declare functions inside other functions and assign them to variables. You can then call them, just like normal functions. We need to pass in `t *testing.T` so that we can tell the test code to fail when we need to.
+
+For helper functions, it's a good idea to accept a `testing.TB` which is an interface that `*testing.T` and `*testing.B` both satisfy, so you can call helper functions from a test, or a benchmark.
 
 `t.Helper()` is needed to tell the test suite that this method is a helper. By doing this when it fails the line number reported will be in our _function call_ rather than inside our test helper. This will help other developers track down problems easier. If you still don't understand, comment it out, make a test fail and observe the test output.
 

--- a/hello-world/v5/hello_test.go
+++ b/hello-world/v5/hello_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestHello(t *testing.T) {
 
-	assertCorrectMessage := func(t *testing.T, got, want string) {
+	assertCorrectMessage := func(t testing.TB, got, want string) {
 		t.Helper()
 		if got != want {
 			t.Errorf("got %q want %q", got, want)

--- a/hello-world/v6/hello_test.go
+++ b/hello-world/v6/hello_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestHello(t *testing.T) {
 
-	assertCorrectMessage := func(t *testing.T, got, want string) {
+	assertCorrectMessage := func(t testing.TB, got, want string) {
 		t.Helper()
 		if got != want {
 			t.Errorf("got %q want %q", got, want)

--- a/hello-world/v8/hello_test.go
+++ b/hello-world/v8/hello_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestHello(t *testing.T) {
 
-	assertCorrectMessage := func(t *testing.T, got, want string) {
+	assertCorrectMessage := func(t testing.TB, got, want string) {
 		t.Helper()
 		if got != want {
 			t.Errorf("got %q want %q", got, want)

--- a/http-server.md
+++ b/http-server.md
@@ -306,7 +306,7 @@ func newGetScoreRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)
@@ -601,7 +601,7 @@ func TestGETPlayers(t *testing.T) {
 	})
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -613,7 +613,7 @@ func newGetScoreRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/http-server/v2/server_test.go
+++ b/http-server/v2/server_test.go
@@ -63,7 +63,7 @@ func TestGETPlayers(t *testing.T) {
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -75,7 +75,7 @@ func newGetScoreRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/http-server/v3/server_test.go
+++ b/http-server/v3/server_test.go
@@ -79,7 +79,7 @@ func TestStoreWins(t *testing.T) {
 	})
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -91,7 +91,7 @@ func newGetScoreRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/http-server/v4/server_test.go
+++ b/http-server/v4/server_test.go
@@ -96,7 +96,7 @@ func TestStoreWins(t *testing.T) {
 	})
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -108,7 +108,7 @@ func newGetScoreRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/http-server/v5/server_test.go
+++ b/http-server/v5/server_test.go
@@ -96,7 +96,7 @@ func TestStoreWins(t *testing.T) {
 	})
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -113,7 +113,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/io.md
+++ b/io.md
@@ -443,7 +443,7 @@ Before adding our test we need to make our other tests compile by replacing the 
 Let's create a helper function which will create a temporary file with some data inside it
 
 ```go
-func createTempFile(t *testing.T, initialData string) (io.ReadWriteSeeker, func()) {
+func createTempFile(t testing.TB, initialData string) (io.ReadWriteSeeker, func()) {
     t.Helper()
 
     tmpfile, err := ioutil.TempFile("", "db")
@@ -1010,7 +1010,7 @@ if err != nil {
 In the tests we should assert there is no error. We can make a helper to help with this.
 
 ```go
-func assertNoError(t *testing.T, err error) {
+func assertNoError(t testing.TB, err error) {
     t.Helper()
     if err != nil {
         t.Fatalf("didn't expect an error but got one, %v", err)

--- a/io/v1/server_test.go
+++ b/io/v1/server_test.go
@@ -123,14 +123,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -141,14 +141,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -170,7 +170,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/io/v2/file_system_store_test.go
+++ b/io/v2/file_system_store_test.go
@@ -41,7 +41,7 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)

--- a/io/v2/server_test.go
+++ b/io/v2/server_test.go
@@ -123,14 +123,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -141,14 +141,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -170,7 +170,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/io/v3/file_system_store_test.go
+++ b/io/v3/file_system_store_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (io.ReadWriteSeeker, func()) {
+func createTempFile(t testing.TB, initialData string) (io.ReadWriteSeeker, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -79,7 +79,7 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)

--- a/io/v3/server_test.go
+++ b/io/v3/server_test.go
@@ -123,14 +123,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -141,14 +141,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -170,7 +170,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/io/v4/file_system_store_test.go
+++ b/io/v4/file_system_store_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (io.ReadWriteSeeker, func()) {
+func createTempFile(t testing.TB, initialData string) (io.ReadWriteSeeker, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -94,7 +94,7 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)

--- a/io/v4/server_test.go
+++ b/io/v4/server_test.go
@@ -123,14 +123,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -141,14 +141,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -170,7 +170,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/io/v5/file_system_store_test.go
+++ b/io/v5/file_system_store_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (io.ReadWriteSeeker, func()) {
+func createTempFile(t testing.TB, initialData string) (io.ReadWriteSeeker, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -94,7 +94,7 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)

--- a/io/v5/server_test.go
+++ b/io/v5/server_test.go
@@ -123,14 +123,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -141,14 +141,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -170,7 +170,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/io/v6/file_system_store_test.go
+++ b/io/v6/file_system_store_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (io.ReadWriteSeeker, func()) {
+func createTempFile(t testing.TB, initialData string) (io.ReadWriteSeeker, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -94,7 +94,7 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)

--- a/io/v6/server_test.go
+++ b/io/v6/server_test.go
@@ -123,14 +123,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -141,14 +141,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -170,7 +170,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/io/v7/file_system_store_test.go
+++ b/io/v7/file_system_store_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (*os.File, func()) {
+func createTempFile(t testing.TB, initialData string) (*os.File, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -93,7 +93,7 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)

--- a/io/v7/server_test.go
+++ b/io/v7/server_test.go
@@ -123,14 +123,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -141,14 +141,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -170,7 +170,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/io/v8/file_system_store_test.go
+++ b/io/v8/file_system_store_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (*os.File, func()) {
+func createTempFile(t testing.TB, initialData string) (*os.File, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -110,14 +110,14 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)
 	}
 }
 
-func assertNoError(t *testing.T, err error) {
+func assertNoError(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("didn't expect an error but got one, %v", err)

--- a/io/v8/server_test.go
+++ b/io/v8/server_test.go
@@ -123,14 +123,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -141,14 +141,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -170,7 +170,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/io/v9/file_system_store_test.go
+++ b/io/v9/file_system_store_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (*os.File, func()) {
+func createTempFile(t testing.TB, initialData string) (*os.File, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -110,14 +110,14 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)
 	}
 }
 
-func assertNoError(t *testing.T, err error) {
+func assertNoError(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("didn't expect an error but got one, %v", err)

--- a/io/v9/server_test.go
+++ b/io/v9/server_test.go
@@ -123,14 +123,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -141,14 +141,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -170,7 +170,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/json.md
+++ b/json.md
@@ -605,7 +605,7 @@ t.Run("it returns the league table as JSON", func(t *testing.T) {
 Here are the new helpers
 
 ```go
-func getLeagueFromResponse(t *testing.T, body io.Reader) (league []Player) {
+func getLeagueFromResponse(t testing.TB, body io.Reader) (league []Player) {
 	t.Helper()
 	err := json.NewDecoder(body).Decode(&league)
 
@@ -616,7 +616,7 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) (league []Player) {
 	return
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
@@ -669,7 +669,7 @@ Add a helper for `assertContentType`.
 ```go
 const jsonContentType = "application/json"
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Result().Header.Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)

--- a/json/v1/server_test.go
+++ b/json/v1/server_test.go
@@ -88,7 +88,7 @@ func TestStoreWins(t *testing.T) {
 	})
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -105,7 +105,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/json/v2/server_test.go
+++ b/json/v2/server_test.go
@@ -102,7 +102,7 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -119,7 +119,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/json/v3/server_test.go
+++ b/json/v3/server_test.go
@@ -111,7 +111,7 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -128,7 +128,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/json/v4/server_test.go
+++ b/json/v4/server_test.go
@@ -122,7 +122,7 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) (league []Player) {
+func getLeagueFromResponse(t testing.TB, body io.Reader) (league []Player) {
 	t.Helper()
 	err := json.NewDecoder(body).Decode(&league)
 
@@ -133,14 +133,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) (league []Player) {
 	return
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -162,7 +162,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/json/v5/server_test.go
+++ b/json/v5/server_test.go
@@ -124,14 +124,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Result().Header.Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) (league []Player) {
+func getLeagueFromResponse(t testing.TB, body io.Reader) (league []Player) {
 	t.Helper()
 	err := json.NewDecoder(body).Decode(&league)
 
@@ -142,14 +142,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) (league []Player) {
 	return
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -171,7 +171,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/json/v6/server_test.go
+++ b/json/v6/server_test.go
@@ -124,14 +124,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Result().Header.Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) (league []Player) {
+func getLeagueFromResponse(t testing.TB, body io.Reader) (league []Player) {
 	t.Helper()
 	err := json.NewDecoder(body).Decode(&league)
 
@@ -142,14 +142,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) (league []Player) {
 	return
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -171,7 +171,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/maps.md
+++ b/maps.md
@@ -79,7 +79,7 @@ func TestSearch(t *testing.T) {
     assertStrings(t, got, want)
 }
 
-func assertStrings(t *testing.T, got, want string) {
+func assertStrings(t testing.TB, got, want string) {
     t.Helper()
 
     if got != want {
@@ -219,7 +219,7 @@ t.Run("unknown word", func(t *testing.T) {
 })
 }
 
-func assertError(t *testing.T, got, want error) {
+func assertError(t testing.TB, got, want error) {
     t.Helper()
 
     if got != want {
@@ -323,7 +323,7 @@ func TestAdd(t *testing.T) {
     assertDefinition(t, dictionary, word, definition)
 }
 
-func assertDefinition(t *testing.T, dictionary Dictionary, word, definition string) {
+func assertDefinition(t testing.TB, dictionary Dictionary, word, definition string) {
     t.Helper()
 
     got, err := dictionary.Search(word)
@@ -369,7 +369,7 @@ func TestAdd(t *testing.T) {
     })
 }
 ...
-func assertError(t *testing.T, got, want error) {
+func assertError(t testing.TB, got, want error) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %q want %q", got, want)

--- a/maps/v1/dictionary_test.go
+++ b/maps/v1/dictionary_test.go
@@ -11,7 +11,7 @@ func TestSearch(t *testing.T) {
 	assertStrings(t, got, want)
 }
 
-func assertStrings(t *testing.T, got, want string) {
+func assertStrings(t testing.TB, got, want string) {
 	t.Helper()
 
 	if got != want {

--- a/maps/v2/dictionary_test.go
+++ b/maps/v2/dictionary_test.go
@@ -21,7 +21,7 @@ func TestSearch(t *testing.T) {
 	})
 }
 
-func assertStrings(t *testing.T, got, want string) {
+func assertStrings(t testing.TB, got, want string) {
 	t.Helper()
 
 	if got != want {
@@ -29,7 +29,7 @@ func assertStrings(t *testing.T, got, want string) {
 	}
 }
 
-func assertError(t *testing.T, got, want error) {
+func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
 	if got != want {

--- a/maps/v3/dictionary_test.go
+++ b/maps/v3/dictionary_test.go
@@ -31,7 +31,7 @@ func TestAdd(t *testing.T) {
 	assertDefinition(t, dictionary, word, definition)
 }
 
-func assertStrings(t *testing.T, got, want string) {
+func assertStrings(t testing.TB, got, want string) {
 	t.Helper()
 
 	if got != want {
@@ -39,7 +39,7 @@ func assertStrings(t *testing.T, got, want string) {
 	}
 }
 
-func assertError(t *testing.T, got, want error) {
+func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
 	if got != want {
@@ -47,7 +47,7 @@ func assertError(t *testing.T, got, want error) {
 	}
 }
 
-func assertDefinition(t *testing.T, dictionary Dictionary, word, definition string) {
+func assertDefinition(t testing.TB, dictionary Dictionary, word, definition string) {
 	t.Helper()
 
 	got, err := dictionary.Search(word)

--- a/maps/v4/dictionary_test.go
+++ b/maps/v4/dictionary_test.go
@@ -44,7 +44,7 @@ func TestAdd(t *testing.T) {
 	})
 }
 
-func assertStrings(t *testing.T, got, want string) {
+func assertStrings(t testing.TB, got, want string) {
 	t.Helper()
 
 	if got != want {
@@ -52,7 +52,7 @@ func assertStrings(t *testing.T, got, want string) {
 	}
 }
 
-func assertError(t *testing.T, got, want error) {
+func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
 	if got != want {
@@ -60,7 +60,7 @@ func assertError(t *testing.T, got, want error) {
 	}
 }
 
-func assertDefinition(t *testing.T, dictionary Dictionary, word, definition string) {
+func assertDefinition(t testing.TB, dictionary Dictionary, word, definition string) {
 	t.Helper()
 
 	got, err := dictionary.Search(word)

--- a/maps/v5/dictionary_test.go
+++ b/maps/v5/dictionary_test.go
@@ -44,7 +44,7 @@ func TestAdd(t *testing.T) {
 	})
 }
 
-func TestUpdate(t *testing.T) {
+func TestUpdate(t testing.TB) {
 	word := "test"
 	definition := "this is just a test"
 	dictionary := Dictionary{word: definition}
@@ -55,7 +55,7 @@ func TestUpdate(t *testing.T) {
 	assertDefinition(t, dictionary, word, newDefinition)
 }
 
-func assertStrings(t *testing.T, got, want string) {
+func assertStrings(t testing.TB, got, want string) {
 	t.Helper()
 
 	if got != want {
@@ -63,7 +63,7 @@ func assertStrings(t *testing.T, got, want string) {
 	}
 }
 
-func assertError(t *testing.T, got, want error) {
+func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
 	if got != want {
@@ -71,7 +71,7 @@ func assertError(t *testing.T, got, want error) {
 	}
 }
 
-func assertDefinition(t *testing.T, dictionary Dictionary, word, definition string) {
+func assertDefinition(t testing.TB, dictionary Dictionary, word, definition string) {
 	t.Helper()
 
 	got, err := dictionary.Search(word)

--- a/maps/v6/dictionary_test.go
+++ b/maps/v6/dictionary_test.go
@@ -67,7 +67,7 @@ func TestUpdate(t *testing.T) {
 	})
 }
 
-func assertStrings(t *testing.T, got, want string) {
+func assertStrings(t testing.TB, got, want string) {
 	t.Helper()
 
 	if got != want {
@@ -75,7 +75,7 @@ func assertStrings(t *testing.T, got, want string) {
 	}
 }
 
-func assertError(t *testing.T, got, want error) {
+func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
 	if got != want {
@@ -83,7 +83,7 @@ func assertError(t *testing.T, got, want error) {
 	}
 }
 
-func assertDefinition(t *testing.T, dictionary Dictionary, word, definition string) {
+func assertDefinition(t testing.TB, dictionary Dictionary, word, definition string) {
 	t.Helper()
 
 	got, err := dictionary.Search(word)

--- a/maps/v7/dictionary_test.go
+++ b/maps/v7/dictionary_test.go
@@ -79,7 +79,7 @@ func TestDelete(t *testing.T) {
 	}
 }
 
-func assertStrings(t *testing.T, got, want string) {
+func assertStrings(t testing.TB, got, want string) {
 	t.Helper()
 
 	if got != want {
@@ -87,7 +87,7 @@ func assertStrings(t *testing.T, got, want string) {
 	}
 }
 
-func assertError(t *testing.T, got, want error) {
+func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
 	if got != want {
@@ -95,7 +95,7 @@ func assertError(t *testing.T, got, want error) {
 	}
 }
 
-func assertDefinition(t *testing.T, dictionary Dictionary, word, definition string) {
+func assertDefinition(t testing.TB, dictionary Dictionary, word, definition string) {
 	t.Helper()
 
 	got, err := dictionary.Search(word)

--- a/pointers-and-errors.md
+++ b/pointers-and-errors.md
@@ -324,7 +324,7 @@ There's some duplication in our tests, lets refactor that out.
 ```go
 func TestWallet(t *testing.T) {
 
-    assertBalance := func(t *testing.T, wallet Wallet, want Bitcoin) {
+    assertBalance := func(t testing.TB, wallet Wallet, want Bitcoin) {
         t.Helper()
         got := wallet.Balance()
 
@@ -420,7 +420,7 @@ Remember to import `errors` into your code.
 Let's make a quick test helper for our error check just to help our test read clearer
 
 ```go
-assertError := func(t *testing.T, err error) {
+assertError := func(t testing.TB, err error) {
     t.Helper()
     if err == nil {
         t.Error("wanted an error but didn't get one")
@@ -449,7 +449,7 @@ Assuming that the error ultimately gets returned to the user, let's update our t
 Update our helper for a `string` to compare against.
 
 ```go
-assertError := func(t *testing.T, got error, want string) {
+assertError := func(t testing.TB, got error, want string) {
     t.Helper()
     if got == nil {
         t.Fatal("didn't get an error but wanted one")
@@ -546,7 +546,7 @@ func TestWallet(t *testing.T) {
     })
 }
 
-func assertBalance(t *testing.T, wallet Wallet, want Bitcoin) {
+func assertBalance(t testing.TB, wallet Wallet, want Bitcoin) {
     t.Helper()
     got := wallet.Balance()
 
@@ -555,7 +555,7 @@ func assertBalance(t *testing.T, wallet Wallet, want Bitcoin) {
     }
 }
 
-func assertError(t *testing.T, got error, want error) {
+func assertError(t testing.TB, got error, want error) {
     t.Helper()
     if got == nil {
         t.Fatal("didn't get an error but wanted one")
@@ -618,7 +618,7 @@ func TestWallet(t *testing.T) {
     })
 }
 
-func assertBalance(t *testing.T, wallet Wallet, want Bitcoin) {
+func assertBalance(t testing.TB, wallet Wallet, want Bitcoin) {
     t.Helper()
     got := wallet.Balance()
 
@@ -627,14 +627,14 @@ func assertBalance(t *testing.T, wallet Wallet, want Bitcoin) {
     }
 }
 
-func assertNoError(t *testing.T, got error) {
+func assertNoError(t testing.TB, got error) {
     t.Helper()
     if got != nil {
         t.Fatal("got an error but didn't want one")
     }
 }
 
-func assertError(t *testing.T, got error, want error) {
+func assertError(t testing.TB, got error, want error) {
     t.Helper()
     if got == nil {
         t.Fatal("didn't get an error but wanted one")

--- a/pointers/v2/wallet_test.go
+++ b/pointers/v2/wallet_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestWallet(t *testing.T) {
 
-	assertBalance := func(t *testing.T, wallet Wallet, want Bitcoin) {
+	assertBalance := func(t testing.TB, wallet Wallet, want Bitcoin) {
 		t.Helper()
 		got := wallet.Balance()
 

--- a/pointers/v3/wallet_test.go
+++ b/pointers/v3/wallet_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestWallet(t *testing.T) {
 
-	assertBalance := func(t *testing.T, wallet Wallet, want Bitcoin) {
+	assertBalance := func(t testing.TB, wallet Wallet, want Bitcoin) {
 		t.Helper()
 		got := wallet.Balance()
 
@@ -15,7 +15,7 @@ func TestWallet(t *testing.T) {
 		}
 	}
 
-	assertError := func(t *testing.T, err error) {
+	assertError := func(t testing.TB, err error) {
 		t.Helper()
 		if err == nil {
 			t.Error("wanted an error but didn't get one")

--- a/pointers/v4/wallet_test.go
+++ b/pointers/v4/wallet_test.go
@@ -31,7 +31,7 @@ func TestWallet(t *testing.T) {
 	})
 }
 
-func assertBalance(t *testing.T, wallet Wallet, want Bitcoin) {
+func assertBalance(t testing.TB, wallet Wallet, want Bitcoin) {
 	t.Helper()
 	got := wallet.Balance()
 
@@ -40,14 +40,14 @@ func assertBalance(t *testing.T, wallet Wallet, want Bitcoin) {
 	}
 }
 
-func assertNoError(t *testing.T, got error) {
+func assertNoError(t testing.TB, got error) {
 	t.Helper()
 	if got != nil {
 		t.Fatal("got an error but didn't want one")
 	}
 }
 
-func assertError(t *testing.T, got error, want error) {
+func assertError(t testing.TB, got error, want error) {
 	t.Helper()
 	if got == nil {
 		t.Fatal("didn't get an error but wanted one")

--- a/q-and-a/context-aware-reader/context_aware_reader_test.go
+++ b/q-and-a/context-aware-reader/context_aware_reader_test.go
@@ -53,7 +53,7 @@ func TestContextAwareReader(t *testing.T) {
 	})
 }
 
-func assertBufferHas(t *testing.T, buf []byte, want string) {
+func assertBufferHas(t testing.TB, buf []byte, want string) {
 	t.Helper()
 	got := string(buf)
 	if got != want {

--- a/q-and-a/http-handlers-revisited/still_basic_test.go
+++ b/q-and-a/http-handlers-revisited/still_basic_test.go
@@ -84,7 +84,7 @@ func TestRegisterUser(t *testing.T) {
 	})
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("wanted http status %d but got %d", got, want)

--- a/reflection.md
+++ b/reflection.md
@@ -761,7 +761,7 @@ t.Run("with maps", func(t *testing.T) {
 Here is how `assertContains` is defined
 
 ```go
-func assertContains(t *testing.T, haystack []string, needle string)  {
+func assertContains(t testing.TB, haystack []string, needle string)  {
     t.Helper()
     contains := false
     for _, x := range haystack {

--- a/reflection/v10/reflection_test.go
+++ b/reflection/v10/reflection_test.go
@@ -144,7 +144,7 @@ type Profile struct {
 	City string
 }
 
-func assertContains(t *testing.T, haystack []string, needle string) {
+func assertContains(t testing.TB, haystack []string, needle string) {
 	t.Helper()
 	contains := false
 	for _, x := range haystack {

--- a/reflection/v8/reflection_test.go
+++ b/reflection/v8/reflection_test.go
@@ -106,7 +106,7 @@ type Profile struct {
 	City string
 }
 
-func assertContains(t *testing.T, haystack []string, needle string) {
+func assertContains(t testing.TB, haystack []string, needle string) {
 	t.Helper()
 	contains := false
 	for _, x := range haystack {

--- a/reflection/v9/reflection_test.go
+++ b/reflection/v9/reflection_test.go
@@ -127,7 +127,7 @@ type Profile struct {
 	City string
 }
 
-func assertContains(t *testing.T, haystack []string, needle string) {
+func assertContains(t testing.TB, haystack []string, needle string) {
 	t.Helper()
 	contains := false
 	for _, x := range haystack {

--- a/structs-methods-and-interfaces.md
+++ b/structs-methods-and-interfaces.md
@@ -331,7 +331,7 @@ Let's introduce this by refactoring our tests.
 ```go
 func TestArea(t *testing.T) {
 
-    checkArea := func(t *testing.T, shape Shape, want float64) {
+    checkArea := func(t testing.TB, shape Shape, want float64) {
         t.Helper()
         got := shape.Area()
         if got != want {

--- a/structs/v5/shapes_test.go
+++ b/structs/v5/shapes_test.go
@@ -16,7 +16,7 @@ func TestPerimeter(t *testing.T) {
 
 func TestArea(t *testing.T) {
 
-	checkArea := func(t *testing.T, shape Shape, want float64) {
+	checkArea := func(t testing.TB, shape Shape, want float64) {
 		t.Helper()
 		got := shape.Area()
 		if got != want {

--- a/sync.md
+++ b/sync.md
@@ -104,7 +104,7 @@ t.Run("incrementing the counter 3 times leaves it at 3", func(t *testing.T) {
     assertCounter(t, counter, 3)
 })
 
-func assertCounter(t *testing.T, got Counter, want int)  {
+func assertCounter(t testing.TB, got Counter, want int)  {
 	t.Helper()
 	if got.Value() != want {
 		t.Errorf("got %d, want %d", got.Value(), want)

--- a/sync/v1/sync_test.go
+++ b/sync/v1/sync_test.go
@@ -16,7 +16,7 @@ func TestCounter(t *testing.T) {
 	})
 }
 
-func assertCounter(t *testing.T, got Counter, want int) {
+func assertCounter(t testing.TB, got Counter, want int) {
 	t.Helper()
 	if got.Value() != want {
 		t.Errorf("got %d, want %d", got.Value(), want)

--- a/sync/v2/sync_test.go
+++ b/sync/v2/sync_test.go
@@ -36,7 +36,7 @@ func TestCounter(t *testing.T) {
 
 }
 
-func assertCounter(t *testing.T, got *Counter, want int) {
+func assertCounter(t testing.TB, got *Counter, want int) {
 	t.Helper()
 	if got.Value() != want {
 		t.Errorf("got %d, want %d", got.Value(), want)

--- a/time.md
+++ b/time.md
@@ -999,7 +999,7 @@ const BadPlayerInputErrMsg = "Bad value received for number of players, please t
 Finally our testing around what has been sent to `stdout` is quite verbose, let's write an assert function to clean it up.
 
 ```go
-func assertMessagesSentToUser(t *testing.T, stdout *bytes.Buffer, messages ...string) {
+func assertMessagesSentToUser(t testing.TB, stdout *bytes.Buffer, messages ...string) {
 	t.Helper()
 	want := strings.Join(messages, "")
 	got := stdout.String()

--- a/time/v1/CLI_test.go
+++ b/time/v1/CLI_test.go
@@ -1,12 +1,12 @@
 package poker_test
 
 import (
-	"fmt"
+        "fmt"
 	"github.com/quii/learn-go-with-tests/time/v1"
-	"io"
-	"strings"
-	"testing"
-	"time"
+        "io"
+        "strings"
+        "testing"
+        "time"
 )
 
 type scheduledAlert struct {
@@ -115,7 +115,7 @@ func (m failOnEndReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-func assertScheduledAlert(t *testing.T, got, want scheduledAlert) {
+func assertScheduledAlert(t testing.TB, got, want scheduledAlert) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %+v, want %+v", got, want)

--- a/time/v1/file_system_store_test.go
+++ b/time/v1/file_system_store_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (*os.File, func()) {
+func createTempFile(t testing.TB, initialData string) (*os.File, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -110,14 +110,14 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)
 	}
 }
 
-func assertNoError(t *testing.T, err error) {
+func assertNoError(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("didn't expect an error but got one, %v", err)

--- a/time/v1/server_test.go
+++ b/time/v1/server_test.go
@@ -97,14 +97,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -115,14 +115,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -144,7 +144,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/time/v1/testing.go
+++ b/time/v1/testing.go
@@ -26,7 +26,7 @@ func (s *StubPlayerStore) GetLeague() League {
 }
 
 // AssertPlayerWin allows you to spy on the store's calls to RecordWin.
-func AssertPlayerWin(t *testing.T, store *StubPlayerStore, winner string) {
+func AssertPlayerWin(t testing.TB, store *StubPlayerStore, winner string) {
 	t.Helper()
 
 	if len(store.WinCalls) != 1 {

--- a/time/v2/CLI_test.go
+++ b/time/v2/CLI_test.go
@@ -2,10 +2,11 @@ package poker_test
 
 import (
 	"bytes"
-	"github.com/quii/learn-go-with-tests/time/v2"
 	"io"
 	"strings"
 	"testing"
+
+	poker "github.com/quii/learn-go-with-tests/time/v2"
 )
 
 var dummyBlindAlerter = &poker.SpyBlindAlerter{}
@@ -102,7 +103,7 @@ func (m failOnEndReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-func assertScheduledAlert(t *testing.T, got, want poker.ScheduledAlert) {
+func assertScheduledAlert(t testing.TB, got, want poker.ScheduledAlert) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %+v, want %+v", got, want)

--- a/time/v2/file_system_store_test.go
+++ b/time/v2/file_system_store_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (*os.File, func()) {
+func createTempFile(t testing.TB, initialData string) (*os.File, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -110,14 +110,14 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)
 	}
 }
 
-func assertNoError(t *testing.T, err error) {
+func assertNoError(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("didn't expect an error but got one, %v", err)

--- a/time/v2/server_test.go
+++ b/time/v2/server_test.go
@@ -97,14 +97,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -115,14 +115,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -144,7 +144,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/time/v2/testing.go
+++ b/time/v2/testing.go
@@ -30,7 +30,7 @@ func (s *StubPlayerStore) GetLeague() League {
 }
 
 // AssertPlayerWin allows you to spy on the store's calls to RecordWin.
-func AssertPlayerWin(t *testing.T, store *StubPlayerStore, winner string) {
+func AssertPlayerWin(t testing.TB, store *StubPlayerStore, winner string) {
 	t.Helper()
 
 	if len(store.WinCalls) != 1 {

--- a/time/v3/CLI_test.go
+++ b/time/v3/CLI_test.go
@@ -2,10 +2,11 @@ package poker_test
 
 import (
 	"bytes"
-	"github.com/quii/learn-go-with-tests/time/v3"
 	"io"
 	"strings"
 	"testing"
+
+	poker "github.com/quii/learn-go-with-tests/time/v3"
 )
 
 var dummyBlindAlerter = &poker.SpyBlindAlerter{}
@@ -90,35 +91,35 @@ func TestCLI(t *testing.T) {
 	})
 }
 
-func assertGameStartedWith(t *testing.T, game *GameSpy, numberOfPlayersWanted int) {
+func assertGameStartedWith(t testing.TB, game *GameSpy, numberOfPlayersWanted int) {
 	t.Helper()
 	if game.StartCalledWith != numberOfPlayersWanted {
 		t.Errorf("wanted Start called with %d but got %d", numberOfPlayersWanted, game.StartCalledWith)
 	}
 }
 
-func assertGameNotFinished(t *testing.T, game *GameSpy) {
+func assertGameNotFinished(t testing.TB, game *GameSpy) {
 	t.Helper()
 	if game.FinishedCalled {
 		t.Errorf("game should not have finished")
 	}
 }
 
-func assertGameNotStarted(t *testing.T, game *GameSpy) {
+func assertGameNotStarted(t testing.TB, game *GameSpy) {
 	t.Helper()
 	if game.StartCalled {
 		t.Errorf("game should not have started")
 	}
 }
 
-func assertFinishCalledWith(t *testing.T, game *GameSpy, winner string) {
+func assertFinishCalledWith(t testing.TB, game *GameSpy, winner string) {
 	t.Helper()
 	if game.FinishCalledWith != winner {
 		t.Errorf("expected finish called with %q but got %q", winner, game.FinishCalledWith)
 	}
 }
 
-func assertMessagesSentToUser(t *testing.T, stdout *bytes.Buffer, messages ...string) {
+func assertMessagesSentToUser(t testing.TB, stdout *bytes.Buffer, messages ...string) {
 	t.Helper()
 	want := strings.Join(messages, "")
 	got := stdout.String()
@@ -127,7 +128,7 @@ func assertMessagesSentToUser(t *testing.T, stdout *bytes.Buffer, messages ...st
 	}
 }
 
-func assertScheduledAlert(t *testing.T, got, want poker.ScheduledAlert) {
+func assertScheduledAlert(t testing.TB, got, want poker.ScheduledAlert) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %+v, want %+v", got, want)

--- a/time/v3/file_system_store_test.go
+++ b/time/v3/file_system_store_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (*os.File, func()) {
+func createTempFile(t testing.TB, initialData string) (*os.File, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -110,14 +110,14 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)
 	}
 }
 
-func assertNoError(t *testing.T, err error) {
+func assertNoError(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("didn't expect an error but got one, %v", err)

--- a/time/v3/server_test.go
+++ b/time/v3/server_test.go
@@ -97,14 +97,14 @@ func TestLeague(t *testing.T) {
 	})
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -115,14 +115,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got, want int) {
+func assertStatus(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("did not get correct status, got %d, want %d", got, want)
@@ -144,7 +144,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/time/v3/testing.go
+++ b/time/v3/testing.go
@@ -30,7 +30,7 @@ func (s *StubPlayerStore) GetLeague() League {
 }
 
 // AssertPlayerWin allows you to spy on the store's calls to RecordWin.
-func AssertPlayerWin(t *testing.T, store *StubPlayerStore, winner string) {
+func AssertPlayerWin(t testing.TB, store *StubPlayerStore, winner string) {
 	t.Helper()
 
 	if len(store.WinCalls) != 1 {

--- a/todo/todo1_test.go
+++ b/todo/todo1_test.go
@@ -58,7 +58,7 @@ func TestToDo(t *testing.T) {
 	})
 }
 
-func assertTodoLength(t *testing.T, list []string, want int) {
+func assertTodoLength(t testing.TB, list []string, want int) {
 	t.Helper()
 	got := len(list)
 	if got != want {
@@ -66,7 +66,7 @@ func assertTodoLength(t *testing.T, list []string, want int) {
 	}
 }
 
-func assertFirstTodoEquaL(t *testing.T, todos []string, item string) {
+func assertFirstTodoEquaL(t testing.TB, todos []string, item string) {
 	t.Helper()
 	if todos[0] != item {
 		t.Errorf("want %s, got %s", item, todos[0])

--- a/websockets.md
+++ b/websockets.md
@@ -414,7 +414,7 @@ func mustDialWS(t *testing.T, url string) *websocket.Conn {
 Finally in our test code we can create a helper to tidy up sending messages
 
 ```go
-func writeWSMessage(t *testing.T, conn *websocket.Conn, message string) {
+func writeWSMessage(t testing.TB, conn *websocket.Conn, message string) {
 	t.Helper()
 	if err := conn.WriteMessage(websocket.TextMessage, []byte(message)); err != nil {
 		t.Fatalf("could not send message over ws connection %v", err)
@@ -947,7 +947,7 @@ You should find the test hangs forever. This is because `ws.ReadMessage()` will 
 We should never have tests that hang so let's introduce a way of handling code that we want to timeout.
 
 ```go
-func within(t *testing.T, d time.Duration, assert func()) {
+func within(t testing.TB, d time.Duration, assert func()) {
 	t.Helper()
 
 	done := make(chan struct{}, 1)
@@ -1042,7 +1042,7 @@ We can refactor our helpers `assertGameStartedWith` and `assertFinishCalledWith`
 Here's how you can do it for `assertFinishCalledWith` and you can use the same approach for the other helper.
 
 ```go
-func assertFinishCalledWith(t *testing.T, game *GameSpy, winner string) {
+func assertFinishCalledWith(t testing.TB, game *GameSpy, winner string) {
 	t.Helper()
 
 	passed := retryUntil(500*time.Millisecond, func() bool {

--- a/websockets/v1/CLI_test.go
+++ b/websockets/v1/CLI_test.go
@@ -2,10 +2,11 @@ package poker_test
 
 import (
 	"bytes"
-	"github.com/quii/learn-go-with-tests/websockets/v1"
 	"io"
 	"strings"
 	"testing"
+
+	poker "github.com/quii/learn-go-with-tests/websockets/v1"
 )
 
 var dummyBlindAlerter = &poker.SpyBlindAlerter{}
@@ -90,35 +91,35 @@ func TestCLI(t *testing.T) {
 	})
 }
 
-func assertGameStartedWith(t *testing.T, game *GameSpy, numberOfPlayersWanted int) {
+func assertGameStartedWith(t testing.TB, game *GameSpy, numberOfPlayersWanted int) {
 	t.Helper()
 	if game.StartCalledWith != numberOfPlayersWanted {
 		t.Errorf("wanted Start called with %d but got %d", numberOfPlayersWanted, game.StartCalledWith)
 	}
 }
 
-func assertGameNotFinished(t *testing.T, game *GameSpy) {
+func assertGameNotFinished(t testing.TB, game *GameSpy) {
 	t.Helper()
 	if game.FinishedCalled {
 		t.Errorf("game should not have finished")
 	}
 }
 
-func assertGameNotStarted(t *testing.T, game *GameSpy) {
+func assertGameNotStarted(t testing.TB, game *GameSpy) {
 	t.Helper()
 	if game.StartCalled {
 		t.Errorf("game should not have started")
 	}
 }
 
-func assertFinishCalledWith(t *testing.T, game *GameSpy, winner string) {
+func assertFinishCalledWith(t testing.TB, game *GameSpy, winner string) {
 	t.Helper()
 	if game.FinishCalledWith != winner {
 		t.Errorf("expected finish called with %q but got %q", winner, game.FinishCalledWith)
 	}
 }
 
-func assertMessagesSentToUser(t *testing.T, stdout *bytes.Buffer, messages ...string) {
+func assertMessagesSentToUser(t testing.TB, stdout *bytes.Buffer, messages ...string) {
 	t.Helper()
 	want := strings.Join(messages, "")
 	got := stdout.String()
@@ -127,7 +128,7 @@ func assertMessagesSentToUser(t *testing.T, stdout *bytes.Buffer, messages ...st
 	}
 }
 
-func assertScheduledAlert(t *testing.T, got, want poker.ScheduledAlert) {
+func assertScheduledAlert(t testing.TB, got, want poker.ScheduledAlert) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %+v, want %+v", got, want)

--- a/websockets/v1/file_system_store_test.go
+++ b/websockets/v1/file_system_store_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func createTempFile(t *testing.T, initialData string) (*os.File, func()) {
+func createTempFile(t testing.TB, initialData string) (*os.File, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -110,14 +110,14 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)
 	}
 }
 
-func assertNoError(t *testing.T, err error) {
+func assertNoError(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("didn't expect an error but got one, %v", err)

--- a/websockets/v1/server_test.go
+++ b/websockets/v1/server_test.go
@@ -2,7 +2,6 @@ package poker
 
 import (
 	"fmt"
-	"github.com/gorilla/websocket"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 func mustMakePlayerServer(t *testing.T, store PlayerStore) *PlayerServer {
@@ -141,21 +142,21 @@ func TestGame(t *testing.T) {
 	})
 }
 
-func writeWSMessage(t *testing.T, conn *websocket.Conn, message string) {
+func writeWSMessage(t testing.TB, conn *websocket.Conn, message string) {
 	t.Helper()
 	if err := conn.WriteMessage(websocket.TextMessage, []byte(message)); err != nil {
 		t.Fatalf("could not send message over ws connection %v", err)
 	}
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
 	}
 }
 
-func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
+func getLeagueFromResponse(t testing.TB, body io.Reader) []Player {
 	t.Helper()
 	league, err := NewLeague(body)
 
@@ -166,14 +167,14 @@ func getLeagueFromResponse(t *testing.T, body io.Reader) []Player {
 	return league
 }
 
-func assertLeague(t *testing.T, got, want []Player) {
+func assertLeague(t testing.TB, got, want []Player) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
 
-func assertStatus(t *testing.T, got *httptest.ResponseRecorder, want int) {
+func assertStatus(t testing.TB, got *httptest.ResponseRecorder, want int) {
 	t.Helper()
 	if got.Code != want {
 		t.Errorf("did not get correct status, got %d, want %d", got.Code, want)
@@ -200,7 +201,7 @@ func newPostWinRequest(name string) *http.Request {
 	return req
 }
 
-func assertResponseBody(t *testing.T, got, want string) {
+func assertResponseBody(t testing.TB, got, want string) {
 	t.Helper()
 	if got != want {
 		t.Errorf("response body is wrong, got %q want %q", got, want)

--- a/websockets/v1/testing.go
+++ b/websockets/v1/testing.go
@@ -30,7 +30,7 @@ func (s *StubPlayerStore) GetLeague() League {
 }
 
 // AssertPlayerWin allows you to spy on the store's calls to RecordWin.
-func AssertPlayerWin(t *testing.T, store *StubPlayerStore, winner string) {
+func AssertPlayerWin(t testing.TB, store *StubPlayerStore, winner string) {
 	t.Helper()
 
 	if len(store.WinCalls) != 1 {

--- a/websockets/v2/CLI_test.go
+++ b/websockets/v2/CLI_test.go
@@ -2,11 +2,12 @@ package poker_test
 
 import (
 	"bytes"
-	"github.com/quii/learn-go-with-tests/websockets/v2"
 	"io"
 	"strings"
 	"testing"
 	"time"
+
+	poker "github.com/quii/learn-go-with-tests/websockets/v2"
 )
 
 var dummyBlindAlerter = &poker.SpyBlindAlerter{}
@@ -89,7 +90,7 @@ func TestCLI(t *testing.T) {
 	})
 }
 
-func assertGameStartedWith(t *testing.T, game *GameSpy, numberOfPlayersWanted int) {
+func assertGameStartedWith(t testing.TB, game *GameSpy, numberOfPlayersWanted int) {
 	t.Helper()
 
 	passed := retryUntil(500*time.Millisecond, func() bool {
@@ -101,21 +102,21 @@ func assertGameStartedWith(t *testing.T, game *GameSpy, numberOfPlayersWanted in
 	}
 }
 
-func assertGameNotFinished(t *testing.T, game *GameSpy) {
+func assertGameNotFinished(t testing.TB, game *GameSpy) {
 	t.Helper()
 	if game.FinishedCalled {
 		t.Errorf("game should not have finished")
 	}
 }
 
-func assertGameNotStarted(t *testing.T, game *GameSpy) {
+func assertGameNotStarted(t testing.TB, game *GameSpy) {
 	t.Helper()
 	if game.StartCalled {
 		t.Errorf("game should not have started")
 	}
 }
 
-func assertFinishCalledWith(t *testing.T, game *GameSpy, winner string) {
+func assertFinishCalledWith(t testing.TB, game *GameSpy, winner string) {
 	t.Helper()
 
 	passed := retryUntil(500*time.Millisecond, func() bool {
@@ -127,7 +128,7 @@ func assertFinishCalledWith(t *testing.T, game *GameSpy, winner string) {
 	}
 }
 
-func assertMessagesSentToUser(t *testing.T, stdout *bytes.Buffer, messages ...string) {
+func assertMessagesSentToUser(t testing.TB, stdout *bytes.Buffer, messages ...string) {
 	t.Helper()
 	want := strings.Join(messages, "")
 	got := stdout.String()
@@ -136,7 +137,7 @@ func assertMessagesSentToUser(t *testing.T, stdout *bytes.Buffer, messages ...st
 	}
 }
 
-func assertScheduledAlert(t *testing.T, got, want poker.ScheduledAlert) {
+func assertScheduledAlert(t testing.TB, got, want poker.ScheduledAlert) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %+v, want %+v", got, want)

--- a/websockets/v2/file_system_store_test.go
+++ b/websockets/v2/file_system_store_test.go
@@ -1,13 +1,14 @@
 package poker_test
 
 import (
-	"github.com/quii/learn-go-with-tests/websockets/v2"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	poker "github.com/quii/learn-go-with-tests/websockets/v2"
 )
 
-func createTempFile(t *testing.T, initialData string) (*os.File, func()) {
+func createTempFile(t testing.TB, initialData string) (*os.File, func()) {
 	t.Helper()
 
 	tmpfile, err := ioutil.TempFile("", "db")
@@ -111,14 +112,14 @@ func TestFileSystemStore(t *testing.T) {
 	})
 }
 
-func assertScoreEquals(t *testing.T, got, want int) {
+func assertScoreEquals(t testing.TB, got, want int) {
 	t.Helper()
 	if got != want {
 		t.Errorf("got %d want %d", got, want)
 	}
 }
 
-func assertNoError(t *testing.T, err error) {
+func assertNoError(t testing.TB, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf("didn't expect an error but got one, %v", err)

--- a/websockets/v2/server_test.go
+++ b/websockets/v2/server_test.go
@@ -2,8 +2,6 @@ package poker_test
 
 import (
 	"fmt"
-	"github.com/gorilla/websocket"
-	"github.com/quii/learn-go-with-tests/websockets/v2"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +9,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
+	poker "github.com/quii/learn-go-with-tests/websockets/v2"
 )
 
 var (
@@ -159,7 +160,7 @@ func retryUntil(d time.Duration, f func() bool) bool {
 	return false
 }
 
-func within(t *testing.T, d time.Duration, assert func()) {
+func within(t testing.TB, d time.Duration, assert func()) {
 	t.Helper()
 
 	done := make(chan struct{}, 1)
@@ -176,14 +177,14 @@ func within(t *testing.T, d time.Duration, assert func()) {
 	}
 }
 
-func writeWSMessage(t *testing.T, conn *websocket.Conn, message string) {
+func writeWSMessage(t testing.TB, conn *websocket.Conn, message string) {
 	t.Helper()
 	if err := conn.WriteMessage(websocket.TextMessage, []byte(message)); err != nil {
 		t.Fatalf("could not send message over ws connection %v", err)
 	}
 }
 
-func assertContentType(t *testing.T, response *httptest.ResponseRecorder, want string) {
+func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
 		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)

--- a/websockets/v2/testing.go
+++ b/websockets/v2/testing.go
@@ -31,7 +31,7 @@ func (s *StubPlayerStore) GetLeague() League {
 }
 
 // AssertPlayerWin allows you to spy on the store's calls to RecordWin.
-func AssertPlayerWin(t *testing.T, store *StubPlayerStore, winner string) {
+func AssertPlayerWin(t testing.TB, store *StubPlayerStore, winner string) {
 	t.Helper()
 
 	if len(store.WinCalls) != 1 {


### PR DESCRIPTION
For helper functions, it's a good idea to accept a `testing.TB` which is an interface that `*testing.T` and `*testing.B` both satisfy, so you can call helper functions from a test, or a benchmark.