### PR TITLE
Fix typo in hello world

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -155,7 +155,7 @@ func Hello(name string) string {
 }
 ```
 
-If you try and run your tests again your `main.go` will fail to compile because you're not passing an argument. Send in "world" to make it pass.
+If you try and run your tests again your `hello.go` will fail to compile because you're not passing an argument. Send in "world" to make it pass.
 
 ```go
 func main() {


### PR DESCRIPTION
Consistently refer to file created as hello.go.

Fixes #390