### PR TITLE
Rename TestHandler to TestServer

### DIFF
--- a/context.md
+++ b/context.md
@@ -43,7 +43,7 @@ func (s *StubStore) Fetch() string {
 	return s.response
 }
 
-func TestHandler(t *testing.T) {
+func TestServer(t *testing.T) {
 	data := "hello, world"
 	svr := Server(&StubStore{data})
 


### PR DESCRIPTION
Latest implementation (v3) using TestServer instead of TestHandler