### PR TITLE
Typo in mocking.md

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -601,7 +601,7 @@ This is usually a sign of you testing too much _implementation detail_. Try to m
 
 It is sometimes hard to know _what level_ to test exactly but here are some thought processes and rules I try to follow:
 
-- **The definition of refactoring is that the code changes but the behaviour stays the same**. If you have decided to do some refactoring in theory you should be able to make a commit without any test changes. So when writing a test ask yourself
+- **The definition of refactoring is that the code changes but the behaviour stays the same**. If you have decided to do some refactoring in theory you should be able to make the commit without any test changes. So when writing a test ask yourself
   - Am I testing the behaviour I want, or the implementation details?
   - If I were to refactor this code, would I have to make lots of changes to the tests?
 - Although Go lets you test private functions, I would avoid it as private functions are implementation detail to support public behaviour. Test the public behaviour. Sandi Metz describes private functions as being "less stable" and you don't want to couple your tests to them.

--- a/mocking.md
+++ b/mocking.md
@@ -601,7 +601,7 @@ This is usually a sign of you testing too much _implementation detail_. Try to m
 
 It is sometimes hard to know _what level_ to test exactly but here are some thought processes and rules I try to follow:
 
-- **The definition of refactoring is that the code changes but the behaviour stays the same**. If you have decided to do some refactoring in theory you should be able to do make the commit without any test changes. So when writing a test ask yourself
+- **The definition of refactoring is that the code changes but the behaviour stays the same**. If you have decided to do some refactoring in theory you should be able to make a commit without any test changes. So when writing a test ask yourself
   - Am I testing the behaviour I want, or the implementation details?
   - If I were to refactor this code, would I have to make lots of changes to the tests?
 - Although Go lets you test private functions, I would avoid it as private functions are implementation detail to support public behaviour. Test the public behaviour. Sandi Metz describes private functions as being "less stable" and you don't want to couple your tests to them.


### PR DESCRIPTION
Removing the word "do" from "in theory you should be able to do make the commit without any test changes."  makes more grammatical sense. 