### PR TITLE
Using a different name for the result variable assignment

### DIFF
--- a/concurrency.md
+++ b/concurrency.md
@@ -420,8 +420,8 @@ func CheckWebsites(wc WebsiteChecker, urls []string) map[string]bool {
 	}
 
 	for i := 0; i < len(urls); i++ {
-		result := <-resultChannel
-		results[result.string] = result.bool
+		r := <-resultChannel
+		results[r.string] = r.bool
 	}
 
 	return results
@@ -454,7 +454,7 @@ we're assigning to is on the left:
 
 ```go
 // Receive expression
-result := <-resultChannel
+r := <-resultChannel
 ```
 
 We then use the `result` received to update the map.

--- a/concurrency/v3/check_websites.go
+++ b/concurrency/v3/check_websites.go
@@ -20,8 +20,8 @@ func CheckWebsites(wc WebsiteChecker, urls []string) map[string]bool {
 	}
 
 	for i := 0; i < len(urls); i++ {
-		result := <-resultChannel
-		results[result.string] = result.bool
+		r := <-resultChannel
+		results[r.string] = r.bool
 	}
 
 	return results


### PR DESCRIPTION
Going through this for the first time and being new go Go I found I found it a little odd that we are using the same name as the type, for the variable assignment. Naming is hard and maybe `r` is not great either, wdyt?
