### PR TITLE
removed duplicate data var

### DIFF
--- a/context.md
+++ b/context.md
@@ -355,7 +355,6 @@ Finally we can update our tests. Comment out our cancellation test so we can fix
 
 ```go
 t.Run("returns data from store", func(t *testing.T) {
-    data := "hello, world"
     store := &SpyStore{response: data, t: t}
     svr := Server(store)
 


### PR DESCRIPTION
The refactor step immediately above this change had moved the data variable declaration to the top of func TestServer.

`go test` was ok that it was declared twice but it seemed like a minor DRY oversight that is worth correcting. My apologies if it is not.