### PR TITLE
Add information about Go modules

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -66,7 +66,30 @@ func TestHello(t *testing.T) {
 }
 ```
 
-Before explaining, let's just run the code. Run `go test` in your terminal. It should've passed! Just to check, try deliberately breaking the test by changing the `want` string.
+## Go modules?
+
+The next step is to run the tests. Enter `go test` in your terminal. If the tests pass, then you are probably using an earlier version of Go. However, if you are using Go 1.16 or later, then the tests will likely not run at all. Instead, you will see an error message like this in the terminal:
+
+```shell
+$ go test
+go: cannot find main module; see 'go help modules'
+```
+
+What's the problem? In a word, [modules](https://blog.golang.org/go116-module-changes). Luckily, the problem is easy to fix. Enter `go mod init` in your terminal. That will create a new file with the following contents:
+
+```go
+module hello
+
+go 1.16
+```
+
+This file tells the `go` tools essential information about your code. If you planned to distribute your application, you would include where the code was available for download as well as information about dependencies. For now, your module file is minimal, and you can leave it that way. To read more about modules [you should check out the reference in the Golang documentation](https://golang.org/doc/modules/gomod-ref). We can get back to testing and learning go now since the tests should run, even on Go 1.16.
+
+One other note, in future chapters you will need to run `go mod init` in each new folder before running commands like `go test` or `go build`.
+
+## Back to Testing
+
+Run `go test` in your terminal. It should've passed! Just to check, try deliberately breaking the test by changing the `want` string.
 
 Notice how you have not had to pick between multiple testing frameworks and then figure out how to install. Everything you need is built in to the language and the syntax is the same as the rest of the code you will write.
 

--- a/hello-world.md
+++ b/hello-world.md
@@ -83,7 +83,7 @@ module hello
 go 1.16
 ```
 
-This file tells the `go` tools essential information about your code. If you planned to distribute your application, you would include where the code was available for download as well as information about dependencies. For now, your module file is minimal, and you can leave it that way. To read more about modules [you should check out the reference in the Golang documentation](https://golang.org/doc/modules/gomod-ref). We can get back to testing and learning Go now since the tests should run, even on Go 1.16.
+This file tells the `go` tools essential information about your code. If you planned to distribute your application, you would include where the code was available for download as well as information about dependencies. For now, your module file is minimal, and you can leave it that way. To read more about modules, [you can check out the reference in the Golang documentation](https://golang.org/doc/modules/gomod-ref). We can get back to testing and learning Go now since the tests should run, even on Go 1.16.
 
 One other note, in future chapters you will need to run `go mod init` in each new folder before running commands like `go test` or `go build`.
 

--- a/hello-world.md
+++ b/hello-world.md
@@ -83,7 +83,7 @@ module hello
 go 1.16
 ```
 
-This file tells the `go` tools essential information about your code. If you planned to distribute your application, you would include where the code was available for download as well as information about dependencies. For now, your module file is minimal, and you can leave it that way. To read more about modules [you should check out the reference in the Golang documentation](https://golang.org/doc/modules/gomod-ref). We can get back to testing and learning go now since the tests should run, even on Go 1.16.
+This file tells the `go` tools essential information about your code. If you planned to distribute your application, you would include where the code was available for download as well as information about dependencies. For now, your module file is minimal, and you can leave it that way. To read more about modules [you should check out the reference in the Golang documentation](https://golang.org/doc/modules/gomod-ref). We can get back to testing and learning Go now since the tests should run, even on Go 1.16.
 
 One other note, in future chapters you will need to run `go mod init` in each new folder before running commands like `go test` or `go build`.
 


### PR DESCRIPTION
This is a quick pass at including information about Go modules. I kept
things very brief, but this should allow people on Go 1.16 (or later) to
continue with the tutorial.

I mentioned that people should run `go mod init` in all future folders,
but perhaps it would be kinder to add that command to all subsequent
chapters? I couldn't decide, but this is a start.

Thanks again for the book!