### PR TITLE
Use t.Error where appropriate in Context section

### DIFF
--- a/context.md
+++ b/context.md
@@ -108,7 +108,7 @@ t.Run("tells store to cancel work if request is cancelled", func(t *testing.T) {
       svr.ServeHTTP(response, request)
 
       if !store.cancelled {
-          t.Errorf("store was not told to cancel")
+          t.Error("store was not told to cancel")
       }
   })
 ```
@@ -214,14 +214,14 @@ type SpyStore struct {
 func (s *SpyStore) assertWasCancelled() {
 	s.t.Helper()
 	if !s.cancelled {
-		s.t.Errorf("store was not told to cancel")
+		s.t.Error("store was not told to cancel")
 	}
 }
 
 func (s *SpyStore) assertWasNotCancelled() {
 	s.t.Helper()
 	if s.cancelled {
-		s.t.Errorf("store was told to cancel")
+		s.t.Error("store was told to cancel")
 	}
 }
 ```

--- a/context/v2/testdoubles.go
+++ b/context/v2/testdoubles.go
@@ -26,13 +26,13 @@ func (s *SpyStore) Cancel() {
 func (s *SpyStore) assertWasCancelled() {
 	s.t.Helper()
 	if !s.cancelled {
-		s.t.Errorf("store was not told to cancel")
+		s.t.Error("store was not told to cancel")
 	}
 }
 
 func (s *SpyStore) assertWasNotCancelled() {
 	s.t.Helper()
 	if s.cancelled {
-		s.t.Errorf("store was told to cancel")
+		s.t.Error("store was told to cancel")
 	}
 }


### PR DESCRIPTION
Thanks so much for this fantastic book. I've really enjoyed it.

I noticed a couple of discrepancies in the Context chapter and I've proposed some changes. Please feel free to let me know if they are invalid changes.

In two instances, `t.Errorf` was being called even though there were no
formatting 'verbs' in the specified errors. They have been replacd with
t.Error in the code snippets in the markdown files as well as the
accompanying code.