### PR TITLE
Add clarifying image above secondHandPoint in math

### DIFF
--- a/math.md
+++ b/math.md
@@ -660,6 +660,10 @@ Remember our unit circle picture?
 
 ![picture of the unit circle with the x and y elements of a ray defined as cos(a) and sin(a) respectively, where a is the angle made by the ray with the x axis](math/images/unit_circle_params.png)
 
+Also recall that we want to measure the angle from 12 o'clock which is the Y axis instead of from the X axis which we would like measuring the angle between the second hand and 3 o'clock.
+
+![unit circle ray defined from by angle from y axis](math/images/unit_circle_12_oclock.png)
+
 We now want the equation that produces X and Y. Let's write it into seconds:
 
 ```go


### PR DESCRIPTION
The unit circle picture that is provided in
<https://quii.gitbook.io/learn-go-with-tests/go-fundamentals/math#write-enough-code-to-make-it-pass-3>
is the standard unit circle which measures angles from the X axis
instead of the Y axis. This may cause readers to use cosine when
calculating X and sin when calculating Y instead of the other way
around. This change adds the image in which the triangle is flipped and
the angle is measured from the Y axis (12 o'clock) and in which X is
clearly shown as sin(α) and Y is shown as cos(α)
