### PR TITLE
fix(command-line): close db if it cannot be parsed

### DIFF
--- a/command-line/v3/file_system_store.go
+++ b/command-line/v3/file_system_store.go
@@ -39,7 +39,7 @@ func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, func(),
 	db, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
 
 	if err != nil {
-		return nil, nil, fmt.Errorf("problem opening %s %v", path, err)
+		return nil, nil, fmt.Errorf("problem opening %s, %v", path, err)
 	}
 
 	closeFunc := func() {
@@ -49,6 +49,7 @@ func FileSystemPlayerStoreFromFile(path string) (*FileSystemPlayerStore, func(),
 	store, err := NewFileSystemPlayerStore(db)
 
 	if err != nil {
+		db.Close()
 		return nil, nil, fmt.Errorf("problem creating file system player store, %v ", err)
 	}
 


### PR DESCRIPTION
If the game db file is corrupt, then it can be opened successfully but parsing the league from it will fail. In this situation `FileSystemPlayerStoreFromFile` wouldn't close the db file.

I have added `db.Close()` into the second error handling block to cure this issue.