### PR TITLE
Make len checks consistent in command-line tests

### DIFF
--- a/command-line.md
+++ b/command-line.md
@@ -216,7 +216,7 @@ func TestCLI(t *testing.T) {
 	cli := &CLI{playerStore, in}
 	cli.PlayPoker()
 
-	if len(playerStore.winCalls) < 1 {
+	if len(playerStore.winCalls) != 1 {
 		t.Fatal("expected a win call but didn't get any")
 	}
 

--- a/command-line/v2/CLI_test.go
+++ b/command-line/v2/CLI_test.go
@@ -10,7 +10,7 @@ func TestCLI(t *testing.T) {
 	cli := &CLI{playerStore}
 	cli.PlayPoker()
 
-	if len(playerStore.winCalls) < 1 {
+	if len(playerStore.winCalls) != 1 {
 		t.Fatal("expected a win call but didn't get any")
 	}
 }


### PR DESCRIPTION
On line 9 of the `CLI_test.go` code snippet in
https://quii.gitbook.io/learn-go-with-tests/build-an-application/command-line#write-the-test-first-1
`playerstore.winCalls` is checked if it is less than 1 `< 1` whereas on
line 11 of the `CLI_test.go` code snippet in
https://quii.gitbook.io/learn-go-with-tests/build-an-application/command-line#write-the-test-first
`playerstore.winCalls` is checked if it is not-equal to 1 `!= 1` and
similarly on line 5 of the `server_test.go` code snippet in
https://quii.gitbook.io/learn-go-with-tests/build-an-application/command-line#refactor
`store.winCalls` is checked if it is not-equal to 1 `!= 1`

This change makes the `playerstore.winCalls` length check on line 9 of
the `CLI_test.go` code snippet in
https://quii.gitbook.io/learn-go-with-tests/build-an-application/command-line#write-the-test-first-1
consistent with the other two checks by switching it to a not-equal `!=`
comparison in the markdown file and in the associated source file.
