### PR TITLE
reflection: Use walkValue to match other branches in switch

### DIFF
--- a/reflection.md
+++ b/reflection.md
@@ -839,7 +839,7 @@ func walk(x interface{}, fn func(input string)) {
 		}
 	case reflect.Chan:
 		for v, ok := val.Recv(); ok; v, ok = val.Recv() {
-			walk(v.Interface(), fn)
+			walkValue(v)
 		}
 	}
 }
@@ -904,12 +904,12 @@ func walk(x interface{}, fn func(input string)) {
 		}
 	case reflect.Chan:
 		for v, ok := val.Recv(); ok; v, ok = val.Recv() {
-			walk(v.Interface(), fn)
+			walkValue(v)
 		}
 	case reflect.Func:
 		valFnResult := val.Call(nil)
 		for _, res := range valFnResult {
-			walk(res.Interface(), fn)
+			walkValue(res)
 		}
 	}
 }

--- a/reflection/v10/reflection.go
+++ b/reflection/v10/reflection.go
@@ -28,12 +28,12 @@ func walk(x interface{}, fn func(input string)) {
 		}
 	case reflect.Chan:
 		for v, ok := val.Recv(); ok; v, ok = val.Recv() {
-			walk(v.Interface(), fn)
+			walkValue(v)
 		}
 	case reflect.Func:
 		valFnResult := val.Call(nil)
 		for _, res := range valFnResult {
-			walk(res.Interface(), fn)
+			walkValue(res)
 		}
 	}
 }

--- a/reflection/v9/reflection.go
+++ b/reflection/v9/reflection.go
@@ -28,7 +28,7 @@ func walk(x interface{}, fn func(input string)) {
 		}
 	case reflect.Chan:
 		for v, ok := val.Recv(); ok; v, ok = val.Recv() {
-			walk(v.Interface(), fn)
+			walkValue(v)
 		}
 	}
 }


### PR DESCRIPTION
I think this change works. go test still passes.﻿

Thanks for the book, I'm enjoying working through it.
