### PR TITLE
Add missing code for ConvertToArabic 'IV' test

### DIFF
--- a/roman-numerals.md
+++ b/roman-numerals.md
@@ -642,6 +642,10 @@ func (r RomanNumerals) ValueOf(symbol string) int {
 	return 0
 }
 
+var allRomanNumerals = RomanNumerals{
+	// content remains unchanged
+}
+
 // later..
 func ConvertToArabic(roman string) int {
 	total := 0


### PR DESCRIPTION
During the refactor to add `type RomanNumerals`, the update to the `allRomanNumerals` assignment was missed.