### PR TITLE
Fix small typo

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -174,7 +174,7 @@ func Hello(name string) string {
 }
 ```
 
-If you try and run your tests again your `hello.go` will fail to compile because you're not passing an argument. Send in "world" to make it pass.
+If you try and run your tests again your `hello.go` will fail to compile because you're not passing an argument. Send in "world" to make it compile.
 
 ```go
 func main() {


### PR DESCRIPTION
Given the context, I believe the text should say "make it compile". The test will not pass at this point.