### PR TITLE
fixing small mistake in explanation

### DIFF
--- a/pointers-and-errors.md
+++ b/pointers-and-errors.md
@@ -243,7 +243,7 @@ func (b Bitcoin) String() string {
 }
 ```
 
-As you can see, the syntax for creating a method on a type alias is the same as it is on a struct.
+As you can see, the syntax for creating a method on a type decleration is the same as it is on a struct.
 
 Next we need to update our test format strings so they will use `String()` instead.
 

--- a/pointers-and-errors.md
+++ b/pointers-and-errors.md
@@ -243,7 +243,7 @@ func (b Bitcoin) String() string {
 }
 ```
 
-As you can see, the syntax for creating a method on a type decleration is the same as it is on a struct.
+As you can see, the syntax for creating a method on a type declaration is the same as it is on a struct.
 
 Next we need to update our test format strings so they will use `String()` instead.
 


### PR DESCRIPTION
`type declaration` is not the same as `type aliasing`.
`type aliasing` is the same as the original type you alias but with a different name.
`type declaration` (aka `type branding`) is taking another type and creating a *completely new type* that "extends" the original type.
https://golang.org/ref/spec#Type_declarations

The type declaration which was used in the guide will make compile errors if we try to pass something that is not `untyped const` or the declared type (Bitcoin) to it.

