### PR TITLE
[math] Remove clockface. from math.md

### DIFF
--- a/math.md
+++ b/math.md
@@ -759,8 +759,8 @@ that acceptance test passing! Let's remind ourselves of what it looks like:
 func TestSecondHandAt30Seconds(t *testing.T) {
 	tm := time.Date(1337, time.January, 1, 0, 0, 30, 0, time.UTC)
 
-	want := clockface.Point{X: 150, Y: 150 + 90}
-	got := clockface.SecondHand(tm)
+	want := Point{X: 150, Y: 150 + 90}
+	got := SecondHand(tm)
 
 	if got != want {
 		t.Errorf("Got %v, wanted %v", got, want)


### PR DESCRIPTION
# why
To fix the code in math.md. [At this point](https://quii.gitbook.io/learn-go-with-tests/go-fundamentals/math#repeat-for-new-requirements-4), `clockface_test.go` is `clockface` package already.
# what

remove `clockface.`