### PR TITLE
fix: Add description regarding an error learner might encounter

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -46,7 +46,16 @@ Here, we are using the `%v` placeholder to print the "default" format, which wor
 
 ## Try to run the test
 
-By running `go test` the compiler will fail with `./sum_test.go:10:15: undefined: Sum`
+If you had initialized go mod with `go mod init main` you will be presented with an error 
+`_testmain.go:13:2: cannot import "main"`. This is because according to common practice, 
+package main will only contain integration of other packages and not unit-testable code and
+hence Go will not allow you to import a package with name `main`.
+
+To fix this, you can rename the main module in `go.mod` to any other name.
+
+Once the above error is fixed, if you run `go test` the compiler will fail with the familiar  
+`./sum_test.go:10:15: undefined: Sum` error. Now we can proceed with writing the actual method
+to be tested.
 
 ## Write the minimal amount of code for the test to run and check the failing test output
 


### PR DESCRIPTION
fix: Add description regarding an error learner might encounter when he/she/they initialize go mod with name of main by looking at the package name in source code