### PR TITLE
Build an application / HTTP server / Make PostgresPlayerStore implement PlayerStore

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@ go get github.com/gorilla/websocket #todo vendor this or learn about the module 
 go get -u golang.org/x/lint/golint
 go get -u github.com/client9/misspell/cmd/misspell
 go get github.com/po3rin/gofmtmd/cmd/gofmtmd
+go get github.com/DATA-DOG/go-sqlmock
 
 ls *.md | xargs misspell -error
 for md_file in ./*.md; do

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/quii/learn-go-with-tests
 go 1.16
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0 // indirect
 	github.com/approvals/go-approval-tests v0.0.0-20211008131110-0c40b30e0000
 	github.com/client9/misspell v0.3.4 // indirect
 	github.com/gomarkdown/markdown v0.0.0-20211212230626-5af6ad2f47df

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/approvals/go-approval-tests v0.0.0-20211008131110-0c40b30e0000 h1:H152l3O+2XIXQu8IrqEXeqJOFCvSShUXs7+x0lw8V1k=
 github.com/approvals/go-approval-tests v0.0.0-20211008131110-0c40b30e0000/go.mod h1:PJOqSY8IofNv3heAD6k8E7EfFS6okiSS9bSAasaAUME=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=

--- a/http-server/v6/in_memory_player_store.go
+++ b/http-server/v6/in_memory_player_store.go
@@ -1,0 +1,32 @@
+package main
+
+import "sync"
+
+// NewInMemoryPlayerStore initialises an empty player store.
+func NewInMemoryPlayerStore() *InMemoryPlayerStore {
+	return &InMemoryPlayerStore{
+		map[string]int{},
+		sync.RWMutex{},
+	}
+}
+
+// InMemoryPlayerStore collects data about players in memory.
+type InMemoryPlayerStore struct {
+	store map[string]int
+	// A mutex is used to synchronize read/write access to the map
+	lock sync.RWMutex
+}
+
+// RecordWin will record a player's win.
+func (i *InMemoryPlayerStore) RecordWin(name string) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+	i.store[name]++
+}
+
+// GetPlayerScore retrieves scores for a given player.
+func (i *InMemoryPlayerStore) GetPlayerScore(name string) int {
+	i.lock.RLock()
+	defer i.lock.RUnlock()
+	return i.store[name]
+}

--- a/http-server/v6/main.go
+++ b/http-server/v6/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func main() {
+	server := &PlayerServer{NewInMemoryPlayerStore()}
+	log.Fatal(http.ListenAndServe(":5000", server))
+}

--- a/http-server/v6/postgres_player_store.go
+++ b/http-server/v6/postgres_player_store.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"database/sql"
+)
+
+// PostgresPlayerStore collects data about players in PostgreSQL DB.
+type PostgresPlayerStore struct {
+	db *sql.DB
+}
+
+// GetPlayerScore retrieves scores for a given player.
+func (p *PostgresPlayerStore) GetPlayerScore(_ string) int {
+	panic("implement me")
+}
+
+// RecordWin will record a player's win.
+func (p *PostgresPlayerStore) RecordWin(name string) {
+	exec, _ := p.db.Exec(`
+insert into playerWins (player, wins) values ($1, 1)
+on conflict (player)
+do update set
+  wins = playerWins.wins + 1
+where playerWins.player = $2 ;`, name, name)
+	_, _ = exec.RowsAffected()
+}

--- a/http-server/v6/postgres_player_store_test.go
+++ b/http-server/v6/postgres_player_store_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestRecordWin(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		mock.ExpectClose()
+		if err := db.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	playerName := "Ron"
+	mock.ExpectExec(`
+insert into playerWins (player, wins) values ($1, 1)
+on conflict (player)
+do update set wins = playerWins.wins + 1 where playerWins.player = $2 ;`,
+	).WithArgs(playerName, playerName).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	storage := PostgresPlayerStore{db}
+	storage.RecordWin(playerName)
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("There were unfulfilled expectation: %s", err)
+	}
+}

--- a/http-server/v6/server.go
+++ b/http-server/v6/server.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// PlayerStore stores score information about players.
+type PlayerStore interface {
+	GetPlayerScore(name string) int
+	RecordWin(name string)
+}
+
+// PlayerServer is a HTTP interface for player information.
+type PlayerServer struct {
+	store PlayerStore
+}
+
+func (p *PlayerServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	player := strings.TrimPrefix(r.URL.Path, "/players/")
+	switch r.Method {
+	case http.MethodPost:
+		p.processWin(w, player)
+	case http.MethodGet:
+		p.showScore(w, player)
+	}
+}
+
+func (p *PlayerServer) showScore(w http.ResponseWriter, player string) {
+	score := p.store.GetPlayerScore(player)
+
+	if score == 0 {
+		w.WriteHeader(http.StatusNotFound)
+	}
+
+	fmt.Fprint(w, score)
+}
+
+func (p *PlayerServer) processWin(w http.ResponseWriter, player string) {
+	p.store.RecordWin(player)
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/http-server/v6/server_integration_test.go
+++ b/http-server/v6/server_integration_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRecordingWinsAndRetrievingThem(t *testing.T) {
+	store := NewInMemoryPlayerStore()
+	server := PlayerServer{store}
+	player := "Pepper"
+
+	server.ServeHTTP(httptest.NewRecorder(), newPostWinRequest(player))
+	server.ServeHTTP(httptest.NewRecorder(), newPostWinRequest(player))
+	server.ServeHTTP(httptest.NewRecorder(), newPostWinRequest(player))
+
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, newGetScoreRequest(player))
+	assertStatus(t, response.Code, http.StatusOK)
+
+	assertResponseBody(t, response.Body.String(), "3")
+}

--- a/http-server/v6/server_test.go
+++ b/http-server/v6/server_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type StubPlayerStore struct {
+	scores   map[string]int
+	winCalls []string
+}
+
+func (s *StubPlayerStore) GetPlayerScore(name string) int {
+	score := s.scores[name]
+	return score
+}
+
+func (s *StubPlayerStore) RecordWin(name string) {
+	s.winCalls = append(s.winCalls, name)
+}
+
+func TestGETPlayers(t *testing.T) {
+	store := StubPlayerStore{
+		map[string]int{
+			"Pepper": 20,
+			"Floyd":  10,
+		},
+		nil,
+	}
+	server := &PlayerServer{&store}
+
+	tests := []struct {
+		name               string
+		player             string
+		expectedHTTPStatus int
+		expectedScore      string
+	}{
+		{
+			name:               "Returns Pepper's score",
+			player:             "Pepper",
+			expectedHTTPStatus: http.StatusOK,
+			expectedScore:      "20",
+		},
+		{
+			name:               "Returns Floyd's score",
+			player:             "Floyd",
+			expectedHTTPStatus: http.StatusOK,
+			expectedScore:      "10",
+		},
+		{
+			name:               "Returns 404 on missing players",
+			player:             "Apollo",
+			expectedHTTPStatus: http.StatusNotFound,
+			expectedScore:      "0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			request := newGetScoreRequest(tt.player)
+			response := httptest.NewRecorder()
+
+			server.ServeHTTP(response, request)
+
+			assertStatus(t, response.Code, tt.expectedHTTPStatus)
+			assertResponseBody(t, response.Body.String(), tt.expectedScore)
+		})
+	}
+}
+
+func TestStoreWins(t *testing.T) {
+	store := StubPlayerStore{
+		map[string]int{},
+		nil,
+	}
+	server := &PlayerServer{&store}
+
+	t.Run("it records wins on POST", func(t *testing.T) {
+		player := "Pepper"
+
+		request := newPostWinRequest(player)
+		response := httptest.NewRecorder()
+
+		server.ServeHTTP(response, request)
+
+		assertStatus(t, response.Code, http.StatusAccepted)
+
+		if len(store.winCalls) != 1 {
+			t.Fatalf("got %d calls to RecordWin want %d", len(store.winCalls), 1)
+		}
+
+		if store.winCalls[0] != player {
+			t.Errorf("did not store correct winner got %q want %q", store.winCalls[0], player)
+		}
+	})
+}
+
+func assertStatus(t testing.TB, got, want int) {
+	t.Helper()
+	if got != want {
+		t.Errorf("did not get correct status, got %d, want %d", got, want)
+	}
+}
+
+func newGetScoreRequest(name string) *http.Request {
+	req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/players/%s", name), nil)
+	return req
+}
+
+func newPostWinRequest(name string) *http.Request {
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("/players/%s", name), nil)
+	return req
+}
+
+func assertResponseBody(t testing.TB, got, want string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("response body is wrong, got %q want %q", got, want)
+	}
+}


### PR DESCRIPTION
Dear Chris!
First of all - let me thank you for the book; it is totally fun and inspiring reading through the chapters!

---

Regarding this PR - I've taken your idea to 
> Make PostgresPlayerStore implement PlayerStore

seriously.


However, failed to follow approach of using go's standard library - leveraged the [sqlmock](https://pkg.go.dev/github.com/DATA-DOG/go-sqlmock), and [testcontainers-go](https://pkg.go.dev/github.com/testcontainers/testcontainers-go) along the way; please let me know if that conflicts the book ideas.

Within starting commits, I've incremented the version (v5 -> v6), and added single test with implementation (as described within [contributing guidelines](https://github.com/quii/learn-go-with-tests/blob/8281d61b3739537c0f096e3d5c537a7196fe57ed/contributing.md#%EF%B8%8F-get-feedback-quickly-for-new-content-%EF%B8%8F))

Glad to hear your thoughts, please take a look!