### PR TITLE
Fix file name BlindAlerter.go to blind_alerter.go in websockets.md

### DIFF
--- a/websockets.md
+++ b/websockets.md
@@ -551,7 +551,7 @@ This works in CLI because we _always want to send the alerts to `os.Stdout`_ but
 
 For that reason we need to change `BlindAlerter.ScheduleAlertAt` so that it takes a destination for the alerts so that we can re-use it in our webserver.
 
-Open BlindAlerter.go and add the parameter `to io.Writer`
+Open blind_alerter.go and add the parameter `to io.Writer`
 
 ```go
 type BlindAlerter interface {


### PR DESCRIPTION
The cctual filename is https://github.com/quii/learn-go-with-tests/blob/main/websockets/v2/blind_alerter.go

`BlindAlerter.go` -> `blind_alerter.go`