### PR TITLE
update github path for code to avoid module path error

### DIFF
--- a/math.md
+++ b/math.md
@@ -134,7 +134,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gypsydave5/learn-go-with-tests/math/v1/clockface"
+	"github.com/quii/learn-go-with-tests/math/v1/clockface"
 )
 
 func TestSecondHandAtMidnight(t *testing.T) {
@@ -195,7 +195,7 @@ and now we get:
     clockface_test.go:17: Got {0 0}, wanted {150 60}
 FAIL
 exit status 1
-FAIL	github.com/gypsydave5/learn-go-with-tests/math/v1/clockface	0.006s
+FAIL	github.com/quii/learn-go-with-tests/math/v1/clockface	0.006s
 ```
 
 ### Write enough code to make it pass
@@ -1134,7 +1134,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gypsydave5/learn-go-with-tests/math/v7b/clockface"
+	"github.com/quii/learn-go-with-tests/math/v7b/clockface"
 )
 
 func main() {
@@ -1830,7 +1830,7 @@ get the remainder of the current hour divided by 12.
 
 ```
 PASS
-ok  	github.com/gypsydave5/learn-go-with-tests/math/v10/clockface	0.008s
+ok  	github.com/quii/learn-go-with-tests/math/v10/clockface	0.008s
 ```
 ### Write the test first
 
@@ -2007,7 +2007,7 @@ The tests will soon tell me if I'm wrong.
 
 ```
 PASS
-ok  	github.com/gypsydave5/learn-go-with-tests/math/v11/clockface	0.009s
+ok  	github.com/quii/learn-go-with-tests/math/v11/clockface	0.009s
 ```
 <!--
 Here endeth v11


### PR DESCRIPTION
I think the github url in the book is outdated - it doesn't reflect that in the code examples 

This changes replaces gypsyjames5 with quii in github urls for the math page 



I got this error
```

sean@rex:~/work/src/github.com/seanburlington/learngowithtests/math$ go mod init
go: creating new go.mod: module github.com/seanburlington/learngowithtests/math
sean@rex:~/work/src/github.com/seanburlington/learngowithtests/math$ go test
go: finding module for package github.com/gypsydave5/learn-go-with-tests/math/v1/clockface
go: downloading github.com/gypsydave5/learn-go-with-tests v0.0.0-20210901120742-4edd2d31fec6
go: found github.com/gypsydave5/learn-go-with-tests/math/v1/clockface in github.com/gypsydave5/learn-go-with-tests v0.0.0-20210901120742-4edd2d31fec6
go: github.com/seanburlington/learngowithtests/math tested by
        github.com/seanburlington/learngowithtests/math.test imports
        github.com/gypsydave5/learn-go-with-tests/math/v1/clockface: github.com/gypsydave5/learn-go-with-tests@v0.0.0-20210901120742-4edd2d31fec6: parsing go.mod:
        module declares its path as: github.com/quii/learn-go-with-tests
                but was required as: github.com/gypsydave5/learn-go-with-tests
```

the gypsydave5 github url returns a 404

https://pkg.go.dev/github.com/gypsydave5/learn-go-with-tests redirects to https://pkg.go.dev/github.com/quii/learn-go-with-tests

So I'm guessing somewhere along the way the url changed - the code examples all have the new url - and the old one seems to result in an error