### PR TITLE
Use go format in code block in intro-to-generics.md

### DIFF
--- a/intro-to-generics.md
+++ b/intro-to-generics.md
@@ -139,7 +139,7 @@ Ideally, we don't want to have to make specific `AssertX` functions for every ty
 
 Generics offer us a new way to make abstractions (like interfaces) by letting us **describe our constraints** in ways we cannot currently do.
 
-```
+```go
 package main
 
 import (
@@ -178,7 +178,7 @@ In our case the type of our type parameter is [`comparable`](https://go.googleso
 
 We're using `comparable` because we want to describe to the compiler that we wish to use the `==` and `!=` operators on things of type `T` in our function, we want to compare! If you try changing the type to `any`,
 
-```
+```go
 func AssertNotEqual[T any](got, want T)
 ```
 
@@ -194,7 +194,7 @@ Which makes a lot of sense, because you can't use those operators on every (or `
 
 Consider two functions
 
-```
+```go
 func GenericFoo[T any](x, y T)
 ```
 
@@ -228,7 +228,7 @@ We're going to create a [stack](https://en.wikipedia.org/wiki/Stack_(abstract_da
 
 For the sake of brevity I've omitted the TDD process that arrived me at the [following code](https://go2goplay.golang.org/p/HghXymv1OKm) for a stack of `int`s, and a stack of `string`s.
 
-```
+```go
 package main
 
 import (
@@ -447,7 +447,7 @@ Just like you can define generic arguments to functions, you can define generic 
 
 Here's our new `Stack` implementation, featuring a generic data type and the tests, showing them working how we'd like them to work, with full type-safety. ([Full code listing here](https://go2goplay.golang.org/p/xAWcaMelgQV))
 
-```
+```go
 package main
 
 import (
@@ -507,7 +507,7 @@ func main() {
 
 You'll notice the syntax for defining generic data structures is consistent with defining generic arguments to functions.
 
-```
+```go
 type Stack[T any] struct {
     values []T
 }
@@ -517,17 +517,17 @@ It's _almost_ the same as before, it's just that what we're saying is the **type
 
 Once you create a `Stack[Orange]` or a `Stack[Apple]` the methods defined on our stack will only let you pass in and will only return the particular type of the stack you're working with:
 
-```
+```go
 func (s *Stack[T]) Pop() (T, bool)
 ```
 
 You can imagine the types of implementation being somehow generated for you, depending on what type of stack you create:
 
-```
+```go
 func (s *Stack[Orange]) Pop() (Orange, bool)
 ```
 
-```
+```go
 func (s *Stack[Apple]) Pop() (Apple, bool)
 ```
 
@@ -569,7 +569,7 @@ Not many people complain about our ability to define interfaces which, like gene
 
 When you consider that if you've used arrays, slices or maps; you've _already been a consumer of generic code_.
 
-```
+```go
 var myApples []Apples
 // You cant do this!
 append(myApples, Orange{})


### PR DESCRIPTION
To make the code block more readable, use `go` format