### PR TITLE
Added additional context to example changes for the 'it returns acept…

### DIFF
--- a/http-server.md
+++ b/http-server.md
@@ -854,24 +854,32 @@ Run the tests and it should be passing! Obviously `"Bob"` isn't exactly what we 
 
 ```go
 //server_test.go
-t.Run("it records wins on POST", func(t *testing.T) {
-	player := "Pepper"
-
-	request := newPostWinRequest(player)
-	response := httptest.NewRecorder()
-
-	server.ServeHTTP(response, request)
-
-	assertStatus(t, response.Code, http.StatusAccepted)
-
-	if len(store.winCalls) != 1 {
-		t.Fatalf("got %d calls to RecordWin want %d", len(store.winCalls), 1)
+func TestStoreWins(t *testing.T) {
+	store := StubPlayerStore{
+		map[string]int{},
+		nil,
 	}
+	server := &PlayerServer{&store}
 
-	if store.winCalls[0] != player {
-		t.Errorf("did not store correct winner got %q want %q", store.winCalls[0], player)
-	}
-})
+	t.Run("it records wins on POST", func(t *testing.T) {
+		player := "Pepper"
+
+		request, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("/players/%s", player), nil)
+		response := httptest.NewRecorder()
+
+		server.ServeHTTP(response, request)
+
+		assertStatus(t, response.Code, http.StatusAccepted)
+
+		if len(store.winCalls) != 1 {
+			t.Fatalf("got %d calls to RecordWin want %d", len(store.winCalls), 1)
+		}
+
+		if store.winCalls[0] != player {
+			t.Errorf("did not store correct winner got %q want %q", store.winCalls[0], player)
+		}
+	})
+}
 ```
 
 Now that we know there is one element in our `winCalls` slice we can safely reference the first one and check it is equal to `player`.


### PR DESCRIPTION
…ed on POST'

As written it was a bit confusing the exact change that needed to be made, so I dug into the example code to look up where it was to go. The main bit of confusion was the name of the test changed. 

I've added the rest of the function around the previous code snippet to add additional context