### PR TITLE
Remove GOPATH related comments

### DIFF
--- a/integers.md
+++ b/integers.md
@@ -138,7 +138,7 @@ By adding this code the example will appear in the documentation inside `godoc`,
 
 To try this out, run `godoc -http=:6060` and navigate to `http://localhost:6060/pkg/`
 
-Inside here you'll see a list of all the packages in your `$GOPATH`, so assuming you wrote this code in somewhere like `$GOPATH/src/github.com/{your_id}` you'll be able to find your example documentation.
+Inside here you'll see a list of all the packages and you'll be able to find your example documentation.
 
 If you publish your code with examples to a public URL, you can share the documentation of your code at [pkg.go.dev](https://pkg.go.dev/). For example, [here](https://pkg.go.dev/github.com/quii/learn-go-with-tests/integers/v2) is the finalised API for this chapter. This web interface allows you to search for documentation of standard library packages and third-party packages.
 


### PR DESCRIPTION
I saw #434 and #399 had intention to remove GOPATH related comments in this book (This is a great book, by the way) so this sentence should be considered differently. That's why I opened this pull request.

And this chapter might need to explain how the packages have docs on `http://localhost:6060/pkg` and how the `adder` example gets there,  when the reader doesn't have GOPATH set up