### PR TITLE
Fix a generics example

### DIFF
--- a/generics.md
+++ b/generics.md
@@ -147,7 +147,7 @@ func AssertEqual[T comparable](t *testing.T, got, want T) {
 func AssertNotEqual[T comparable](t *testing.T, got, want T) {
     t.Helper()
 	if got == want {
-		t.Errorf("didn't want %v", got, want)
+		t.Errorf("didn't want %v", got)
 	}
 }
 ```


### PR DESCRIPTION
This fixes an example in generics.md where the arg count doesn't match the pattern.