### PR TITLE
Add missing format directive to t.Errorf() call

### DIFF
--- a/generics.md
+++ b/generics.md
@@ -147,7 +147,7 @@ func AssertEqual[T comparable](t *testing.T, got, want T) {
 func AssertNotEqual[T comparable](t *testing.T, got, want T) {
     t.Helper()
 	if got == want {
-		t.Errorf("didn't want %v", got, want)
+		t.Errorf("got %v, didn't want %v", got, want)
 	}
 }
 ```


### PR DESCRIPTION
Fixes compilation error: 

`(*testing.common).Errorf call needs 1 arg but has 2 args`

