### PR TITLE
📝 Add note about `any`

### DIFF
--- a/reflection.md
+++ b/reflection.md
@@ -20,7 +20,7 @@ This means that we get some documentation for free and the compiler will complai
 
 You may come across scenarios though where you want to write a function where you don't know the type at compile time.
 
-Go lets us get around this with the type `interface{}` which you can think of as just _any_ type.
+Go lets us get around this with the type `interface{}` which you can think of as just _any_ type (in fact, in Go `any` is an [alias](https://cs.opensource.google/go/go/+/master:test/typeparam/cons.go;drc=master;l=13) for `interface{}`).
 
 So `walk(x interface{}, fn func(string))` will accept any value for `x`.
 

--- a/reflection.md
+++ b/reflection.md
@@ -20,7 +20,7 @@ This means that we get some documentation for free and the compiler will complai
 
 You may come across scenarios though where you want to write a function where you don't know the type at compile time.
 
-Go lets us get around this with the type `interface{}` which you can think of as just _any_ type (in fact, in Go `any` is an [alias](https://cs.opensource.google/go/go/+/master:test/typeparam/cons.go;drc=master;l=13) for `interface{}`).
+Go lets us get around this with the type `interface{}` which you can think of as just _any_ type (in fact, in Go `any` is an [alias](https://cs.opensource.google/go/go/+/master:src/builtin/builtin.go;drc=master;l=95) for `interface{}`).
 
 So `walk(x interface{}, fn func(string))` will accept any value for `x`.
 


### PR DESCRIPTION
The inclusion of `any` in Go 1.18 was controversial, but since it's here we might as well mention it briefly