### PR TITLE
Consistently use US spelling of present participles

### DIFF
--- a/context/v2/context_test.go
+++ b/context/v2/context_test.go
@@ -24,23 +24,23 @@ func TestServer(t *testing.T) {
 			t.Errorf(`got "%s", want "%s"`, response.Body.String(), data)
 		}
 
-		store.assertWasNotCancelled()
+		store.assertWasNotCanceled()
 	})
 
-	t.Run("tells store to cancel work if request is cancelled", func(t *testing.T) {
+	t.Run("tells store to cancel work if request is canceled", func(t *testing.T) {
 		store := &SpyStore{response: data, t: t}
 		svr := Server(store)
 
 		request := httptest.NewRequest(http.MethodGet, "/", nil)
 
-		cancellingCtx, cancel := context.WithCancel(request.Context())
+		cancelingCtx, cancel := context.WithCancel(request.Context())
 		time.AfterFunc(5*time.Millisecond, cancel)
-		request = request.WithContext(cancellingCtx)
+		request = request.WithContext(cancelingCtx)
 
 		response := httptest.NewRecorder()
 
 		svr.ServeHTTP(response, request)
 
-		store.assertWasCancelled()
+		store.assertWasCanceled()
 	})
 }

--- a/context/v2/testdoubles.go
+++ b/context/v2/testdoubles.go
@@ -7,9 +7,9 @@ import (
 
 // SpyStore allows you to simulate a store and see how its used.
 type SpyStore struct {
-	response  string
-	cancelled bool
-	t         *testing.T
+	response string
+	canceled bool
+	t        *testing.T
 }
 
 // Fetch returns response after a short delay.
@@ -20,19 +20,19 @@ func (s *SpyStore) Fetch() string {
 
 // Cancel will record the call.
 func (s *SpyStore) Cancel() {
-	s.cancelled = true
+	s.canceled = true
 }
 
-func (s *SpyStore) assertWasCancelled() {
+func (s *SpyStore) assertWasCanceled() {
 	s.t.Helper()
-	if !s.cancelled {
+	if !s.canceled {
 		s.t.Error("store was not told to cancel")
 	}
 }
 
-func (s *SpyStore) assertWasNotCancelled() {
+func (s *SpyStore) assertWasNotCanceled() {
 	s.t.Helper()
-	if s.cancelled {
+	if s.canceled {
 		s.t.Error("store was told to cancel")
 	}
 }

--- a/context/v3/context_test.go
+++ b/context/v3/context_test.go
@@ -25,15 +25,15 @@ func TestServer(t *testing.T) {
 		}
 	})
 
-	t.Run("tells store to cancel work if request is cancelled", func(t *testing.T) {
+	t.Run("tells store to cancel work if request is canceled", func(t *testing.T) {
 		store := &SpyStore{response: data}
 		svr := Server(store)
 
 		request := httptest.NewRequest(http.MethodGet, "/", nil)
 
-		cancellingCtx, cancel := context.WithCancel(request.Context())
+		cancelingCtx, cancel := context.WithCancel(request.Context())
 		time.AfterFunc(5*time.Millisecond, cancel)
-		request = request.WithContext(cancellingCtx)
+		request = request.WithContext(cancelingCtx)
 
 		response := &SpyResponseWriter{}
 

--- a/context/v3/testdoubles.go
+++ b/context/v3/testdoubles.go
@@ -22,7 +22,7 @@ func (s *SpyStore) Fetch(ctx context.Context) (string, error) {
 		for _, c := range s.response {
 			select {
 			case <-ctx.Done():
-				log.Println("spy store got cancelled")
+				log.Println("spy store got canceled")
 				return
 			default:
 				time.Sleep(10 * time.Millisecond)

--- a/math.md
+++ b/math.md
@@ -967,11 +967,11 @@ to parse it.
 [`encoding/xml`][xml] is the Go package that can handle all things to do with
 simple XML parsing.
 
-The function [`xml.Unmarshall`](https://godoc.org/encoding/xml#Unmarshal) takes
-a `[]byte` of XML data, and a pointer to a struct for it to get unmarshalled in
+The function [`xml.Unmarshal`](https://godoc.org/encoding/xml#Unmarshal) takes
+a `[]byte` of XML data, and a pointer to a struct for it to get unmarshaled in
 to.
 
-So we'll need a struct to unmarshall our XML into. We could spend some time
+So we'll need a struct to unmarshal our XML into. We could spend some time
 working out what the correct names for all of the nodes and attributes, and how
 to write the correct structure but, happily, someone has written
 [`zek`](https://github.com/miku/zek) a program that will automate all of that
@@ -1034,7 +1034,7 @@ func TestSVGWriterAtMidnight(t *testing.T) {
 ```
 
 We write the output of `clockface.SVGWriter` to a `bytes.Buffer`
-and then `Unmarshall` it into an `Svg`. We then look at each `Line` in the `Svg`
+and then `Unmarshal` it into an `Svg`. We then look at each `Line` in the `Svg`
 to see if any of them have the expected `X2` and `Y2` values. If we get a match
 we return early (passing the test); if not we fail with a (hopefully)
 informative message.

--- a/q-and-a/context-aware-reader/context_aware_reader.go
+++ b/q-and-a/context-aware-reader/context_aware_reader.go
@@ -5,8 +5,8 @@ import (
 	"io"
 )
 
-// NewCancellableReader will stop reading to rdr if ctx is cancelled.
-func NewCancellableReader(ctx context.Context, rdr io.Reader) io.Reader {
+// NewCancelableReader will stop reading to rdr if ctx is canceled.
+func NewCancelableReader(ctx context.Context, rdr io.Reader) io.Reader {
 	return &readerCtx{
 		ctx:      ctx,
 		delegate: rdr,

--- a/q-and-a/context-aware-reader/context_aware_reader_test.go
+++ b/q-and-a/context-aware-reader/context_aware_reader_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestContextAwareReader(t *testing.T) {
 	t.Run("behaves like a normal reader", func(t *testing.T) {
-		rdr := NewCancellableReader(context.Background(), strings.NewReader("123456"))
+		rdr := NewCancelableReader(context.Background(), strings.NewReader("123456"))
 		got := make([]byte, 3)
 		_, err := rdr.Read(got)
 
@@ -27,9 +27,9 @@ func TestContextAwareReader(t *testing.T) {
 		assertBufferHas(t, got, "456")
 	})
 
-	t.Run("stops reading when cancelled", func(t *testing.T) {
+	t.Run("stops reading when canceled", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		rdr := NewCancellableReader(ctx, strings.NewReader("123456"))
+		rdr := NewCancelableReader(ctx, strings.NewReader("123456"))
 		got := make([]byte, 3)
 		_, err := rdr.Read(got)
 


### PR DESCRIPTION
Go community prefers the US spelling of words like
"canceling" over "cancelling"; e.g., see https://go.dev/cl/14526.

Fix a few occurrences of the "canceling" inconsistency, as well as "unmarshaling".
But preserve "cancellation".

See also Go core commits:
https://github.com/golang/go/commit/3e7ffb862f550c38ce0611b970a4dce10a01226e
https://github.com/golang/go/commit/d8264de8683dac99ffbbbc1f46415e627b73c9ed
https://github.com/golang/go/commit/431b5c69ca214ce4291f008c1ce2a50b22bc2d2d