### PR TITLE
godoc.org is now pkg.go.dev

### DIFF
--- a/command-line.md
+++ b/command-line.md
@@ -103,7 +103,7 @@ The full path may seem a bit jarring, but this is how you can import _any_ publi
 
 By separating our domain code into a separate package and committing it to a public repo like GitHub any Go developer can write their own code which imports that package the features we've written available. The first time you try and run it will complain it is not existing but all you need to do is run `go get`.
 
-In addition, users can view [the documentation at godoc.org](https://godoc.org/github.com/quii/learn-go-with-tests/command-line/v1).
+In addition, users can view [the documentation at pkg.go.dev](https://pkg.go.dev/github.com/quii/learn-go-with-tests/command-line/v1).
 
 ### Final checks
 

--- a/math.md
+++ b/math.md
@@ -967,7 +967,7 @@ to parse it.
 [`encoding/xml`][xml] is the Go package that can handle all things to do with
 simple XML parsing.
 
-The function [`xml.Unmarshall`](https://godoc.org/encoding/xml#Unmarshal) takes
+The function [`xml.Unmarshall`](https://pkg.go.dev/encoding/xml#Unmarshal) takes
 a `[]byte` of XML data, and a pointer to a struct for it to get unmarshalled in
 to.
 
@@ -2201,4 +2201,4 @@ tests. It is an investment.
 [mathcos]: https://golang.org/pkg/math/#Cos
 [floatingpoint]: https://0.30000000000000004.com/
 [phlip]: http://wiki.c2.com/?PhlIp
-[xml]: https://godoc.org/encoding/xml
+[xml]: https://pkg.go.dev/encoding/xml

--- a/reflection.md
+++ b/reflection.md
@@ -133,7 +133,7 @@ This code is _very unsafe and very naive_, but remember: our goal when we are in
 
 We need to use reflection to have a look at `x` and try and look at its properties.
 
-The [reflect package](https://godoc.org/reflect) has a function `ValueOf` which returns us a `Value` of a given variable. This has ways for us to inspect a value, including its fields which we use on the next line.
+The [reflect package](https://pkg.go.dev/reflect) has a function `ValueOf` which returns us a `Value` of a given variable. This has ways for us to inspect a value, including its fields which we use on the next line.
 
 We then make some very optimistic assumptions about the value passed in
 
@@ -267,7 +267,7 @@ func walk(x interface{}, fn func(input string)) {
 }
 ```
 
-We can do that by checking its [`Kind`](https://godoc.org/reflect#Kind).
+We can do that by checking its [`Kind`](https://pkg.go.dev/reflect#Kind).
 
 ## Refactor
 


### PR DESCRIPTION
In [2020](https://go.dev/blog/pkg.go.dev-2020) godoc.org has been migrated to pkg.go.dev.