### PR TITLE
Removed "Intro to generics" chapter

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -47,6 +47,5 @@
 
 * [Why unit tests and how to make them work for you](why.md)
 * [Anti-patterns](anti-patterns.md)
-* [Intro to generics](intro-to-generics.md)
 * [Contributing](contributing.md)
 * [Chapter Template](template.md)

--- a/intro-to-generics.md
+++ b/intro-to-generics.md
@@ -1,1 +1,0 @@
-[Moved to](./generics.md)


### PR DESCRIPTION
There's no reason to keep the empty chapter, it got moved to Go fundamentals after Go 1.18 released.