### PR TITLE
Replaced HeaderMap as it's deprecated

### DIFF
--- a/command-line/v1/server_test.go
+++ b/command-line/v1/server_test.go
@@ -126,7 +126,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/command-line/v2/server_test.go
+++ b/command-line/v2/server_test.go
@@ -126,7 +126,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/command-line/v3/server_test.go
+++ b/command-line/v3/server_test.go
@@ -100,7 +100,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/io/v1/server_test.go
+++ b/io/v1/server_test.go
@@ -126,7 +126,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/io/v2/server_test.go
+++ b/io/v2/server_test.go
@@ -126,7 +126,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/io/v3/server_test.go
+++ b/io/v3/server_test.go
@@ -126,7 +126,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/io/v4/server_test.go
+++ b/io/v4/server_test.go
@@ -126,7 +126,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/io/v5/server_test.go
+++ b/io/v5/server_test.go
@@ -126,7 +126,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/io/v6/server_test.go
+++ b/io/v6/server_test.go
@@ -126,7 +126,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/io/v7/server_test.go
+++ b/io/v7/server_test.go
@@ -126,7 +126,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/io/v8/server_test.go
+++ b/io/v8/server_test.go
@@ -126,7 +126,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/io/v9/server_test.go
+++ b/io/v9/server_test.go
@@ -126,7 +126,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/time/v1/server_test.go
+++ b/time/v1/server_test.go
@@ -100,7 +100,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/time/v2/server_test.go
+++ b/time/v2/server_test.go
@@ -100,7 +100,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/time/v3/server_test.go
+++ b/time/v3/server_test.go
@@ -100,7 +100,7 @@ func TestLeague(t *testing.T) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/websockets/v1/server_test.go
+++ b/websockets/v1/server_test.go
@@ -152,7 +152,7 @@ func writeWSMessage(t testing.TB, conn *websocket.Conn, message string) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 

--- a/websockets/v2/server_test.go
+++ b/websockets/v2/server_test.go
@@ -187,7 +187,7 @@ func writeWSMessage(t testing.TB, conn *websocket.Conn, message string) {
 func assertContentType(t testing.TB, response *httptest.ResponseRecorder, want string) {
 	t.Helper()
 	if response.Header().Get("content-type") != want {
-		t.Errorf("response did not have content-type of %s, got %v", want, response.HeaderMap)
+		t.Errorf("response did not have content-type of %s, got %v", want, response.Result().Header)
 	}
 }
 


### PR DESCRIPTION
Some of the test code still used `HeaderMap` in their assertions, even tho in the *.md files it's fixed: https://github.com/quii/learn-go-with-tests/blob/a9d05d3511ad2373a166886bf0bcd80a05a61dac/json.md?plain=1#L653