### PR TITLE
Add quotes to switch cases

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -465,9 +465,9 @@ func Hello(name string, language string) string {
 	prefix := englishHelloPrefix
 
 	switch language {
-	case french:
+	case "french":
 		prefix = frenchHelloPrefix
-	case spanish:
+	case "spanish":
 		prefix = spanishHelloPrefix
 	}
 
@@ -492,9 +492,9 @@ func Hello(name string, language string) string {
 
 func greetingPrefix(language string) (prefix string) {
 	switch language {
-	case french:
+	case "french":
 		prefix = frenchHelloPrefix
-	case spanish:
+	case "spanish":
 		prefix = spanishHelloPrefix
 	default:
 		prefix = englishHelloPrefix


### PR DESCRIPTION
I have tried `switch` with and without quotes, and the compiler complains without quotes. The docs on `switch` also has quotes.

(As an aside, should I open an issue first? The contributing guidelines does not say to always make an issue first.)