### PR TITLE
Avoid mac os port conflict

### DIFF
--- a/dependency-injection.md
+++ b/dependency-injection.md
@@ -185,11 +185,11 @@ func MyGreeterHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	log.Fatal(http.ListenAndServe(":5000", http.HandlerFunc(MyGreeterHandler)))
+	log.Fatal(http.ListenAndServe(":5001", http.HandlerFunc(MyGreeterHandler)))
 }
 ```
 
-Run the program and go to [http://localhost:5000](http://localhost:5000). You'll see your greeting function being used.
+Run the program and go to [http://localhost:5001](http://localhost:5001). You'll see your greeting function being used.
 
 HTTP servers will be covered in a later chapter so don't worry too much about the details.
 


### PR DESCRIPTION
I'm running the latest mac os (12.3.1) and I'm not able to start the server with port 5000. It seems like a mac os system app called ControlCentre is using that port so to avoid unnecessary issues I think switching port might be a good idea.

I run these commands to check what's running on port 5000
```
lsof -i -P | grep -i "5000"
```
output
```
ControlCe 98168 trondfroding   19u  IPv4 0x7d09d3228c03ccf3      0t0  TCP *:5000 (LISTEN)
ControlCe 98168 trondfroding   20u  IPv6 0x7d09d31da622b6fb      0t0  TCP *:5000 (LISTEN)
```
when grepping for the those process ids `ps -ef | grep 98168` i get this output
```
  501 98168     1   0  9:41PM ??         0:01.04 /System/Library/CoreServices/ControlCenter.app/Contents/MacOS/ControlCenter
  501 98212 96133   0  9:42PM ttys013    0:00.00 grep 98168
```
When killing the controlcentre process it respawned directly with a new process id and took port 5000 again :( (and also port 6000)

Really appreciate this resource for learning go, has been invaluable to me :) 

Best regards /
Trond