### PR TITLE
Removed redundant Sleep() in Mocking

### DIFF
--- a/mocking/v3/countdown_test.go
+++ b/mocking/v3/countdown_test.go
@@ -21,8 +21,8 @@ Go!`
 		t.Errorf("got %q want %q", got, want)
 	}
 
-	if spySleeper.Calls != 4 {
-		t.Errorf("not enough calls to sleeper, want 4 got %d", spySleeper.Calls)
+	if spySleeper.Calls != 3 {
+		t.Errorf("not enough calls to sleeper, want 3 got %d", spySleeper.Calls)
 	}
 }
 

--- a/mocking/v3/main.go
+++ b/mocking/v3/main.go
@@ -26,11 +26,10 @@ const countdownStart = 3
 // Countdown prints a countdown from 3 to out with a delay between count provided by Sleeper.
 func Countdown(out io.Writer, sleeper Sleeper) {
 	for i := countdownStart; i > 0; i-- {
-		sleeper.Sleep()
 		fmt.Fprintln(out, i)
+		sleeper.Sleep()
 	}
 
-	sleeper.Sleep()
 	fmt.Fprint(out, finalWord)
 }
 

--- a/mocking/v4/countdown_test.go
+++ b/mocking/v4/countdown_test.go
@@ -23,12 +23,11 @@ Go!`
 		}
 	})
 
-	t.Run("sleep before every print", func(t *testing.T) {
+	t.Run("sleep in-between the prints", func(t *testing.T) {
 		spySleepPrinter := &SpyCountdownOperations{}
 		Countdown(spySleepPrinter, spySleepPrinter)
 
 		want := []string{
-			sleep,
 			write,
 			sleep,
 			write,

--- a/mocking/v4/main.go
+++ b/mocking/v4/main.go
@@ -27,11 +27,10 @@ const countdownStart = 3
 func Countdown(out io.Writer, sleeper Sleeper) {
 
 	for i := countdownStart; i > 0; i-- {
-		sleeper.Sleep()
 		fmt.Fprintln(out, i)
+		sleeper.Sleep()
 	}
 
-	sleeper.Sleep()
 	fmt.Fprint(out, finalWord)
 }
 

--- a/mocking/v5/countdown_test.go
+++ b/mocking/v5/countdown_test.go
@@ -29,7 +29,6 @@ Go!`
 		Countdown(spySleepPrinter, spySleepPrinter)
 
 		want := []string{
-			sleep,
 			write,
 			sleep,
 			write,

--- a/mocking/v5/main.go
+++ b/mocking/v5/main.go
@@ -30,11 +30,10 @@ const countdownStart = 3
 func Countdown(out io.Writer, sleeper Sleeper) {
 
 	for i := countdownStart; i > 0; i-- {
-		sleeper.Sleep()
 		fmt.Fprintln(out, i)
+		sleeper.Sleep()
 	}
 
-	sleeper.Sleep()
 	fmt.Fprint(out, finalWord)
 }
 


### PR DESCRIPTION
Changed tests and `main` codes in `mocking/v3/ - v5/` to only call `sleeper.Sleep()` between the prints.  
While editing `mocking.md`, I also made a few grammar corrections there, hope you don't mind. :v: 

Closes:  #583 