### PR TITLE
fix: pointer ch use t.Error instead of Fatal for assertNoError

### DIFF
--- a/pointers-and-errors.md
+++ b/pointers-and-errors.md
@@ -634,7 +634,7 @@ func assertBalance(t testing.TB, wallet Wallet, want Bitcoin) {
 func assertNoError(t testing.TB, got error) {
 	t.Helper()
 	if got != nil {
-		t.Fatal("got an error but didn't want one")
+		t.Error("got an error but didn't want one")
 	}
 }
 

--- a/pointers/v4/wallet_test.go
+++ b/pointers/v4/wallet_test.go
@@ -43,7 +43,7 @@ func assertBalance(t testing.TB, wallet Wallet, want Bitcoin) {
 func assertNoError(t testing.TB, got error) {
 	t.Helper()
 	if got != nil {
-		t.Fatal("got an error but didn't want one")
+		t.Error("got an error but didn't want one")
 	}
 }
 


### PR DESCRIPTION
I don't think there is a need for T.Fatal here. Having it can make it confusing as to why it was introduced for the `assertError` func