### PR TITLE
Fix typo on receiver variables from `struct` example

### DIFF
--- a/structs/v8/shapes.go
+++ b/structs/v8/shapes.go
@@ -40,6 +40,6 @@ type Triangle struct {
 }
 
 // Area returns the area of the triangle.
-func (c Triangle) Area() float64 {
-	return (c.Base * c.Height) * 0.5
+func (t Triangle) Area() float64 {
+	return (t.Base * t.Height) * 0.5
 }


### PR DESCRIPTION
From [the chapter description](https://quii.gitbook.io/learn-go-with-tests/go-fundamentals/structs-methods-and-interfaces#write-the-minimal-amount-of-code-for-the-test-to-run-and-check-the-failing-test-output-2), it suggests using the first letter of the receiver type as a receiver variable.

Therefore, I slightly changed receiver variable letters from c to t (since type is Triangle) in structs/v8/shapes.go.

Thanks!