### PR TITLE
fix: Consistent example code for SumAll() example

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -289,7 +289,7 @@ We need to define `SumAll` according to what our test wants.
 Go can let you write [_variadic functions_](https://gobyexample.com/variadic-functions) that can take a variable number of arguments.
 
 ```go
-func SumAll(numbersToSum ...[]int) (sums []int) {
+func SumAll(numbersToSum ...[]int) []int {
 	return
 }
 ```


### PR DESCRIPTION
The first code example showing the shape of the `SumAll()` function has a named return value in it of `(sum []int)` where later examples drop the named return value. If learners are not careful and notice the change, they may overlook the different return signature and get surprised by a `NoNewVar` error later on in the process when `sum := ...` is written.
https://pkg.go.dev/golang.org/x/tools/internal/typesinternal#NoNewVar

This changes the initial entry to line up with the rest of the examples in the document.