### PR TITLE
maps.md: use tabs in code example

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -508,7 +508,7 @@ There is no refactoring we need to do on this since it was a simple change. Howe
 t.Run("existing word", func(t *testing.T) {
 	word := "test"
 	definition := "this is just a test"
-    dictionary := Dictionary{word: definition}
+	dictionary := Dictionary{word: definition}
 	newDefinition := "new definition"
 
 	err := dictionary.Update(word, newDefinition)


### PR DESCRIPTION
The use of spaces is currently causing the generated html code to be misaligned.

![image](https://user-images.githubusercontent.com/119276/188457171-9bc57a6c-d5c9-4fb6-b8d7-0a72476a0fcf.png)
