### PR TITLE
Remove confuse import in clockface test

### DIFF
--- a/math.md
+++ b/math.md
@@ -133,8 +133,6 @@ package clockface_test
 import (
 	"testing"
 	"time"
-
-	"github.com/gypsydave5/learn-go-with-tests/math/v1/clockface"
 )
 
 func TestSecondHandAtMidnight(t *testing.T) {


### PR DESCRIPTION
In first code demo, it import "github.com/gypsydave5/learn-go-with-tests/math/v1/clockface". But learner need create clockface.go by themself and that import cause confusing