### PR TITLE
Use `%p` to print &wallet.Balance in pointers-and-errors.md

### DIFF
--- a/pointers-and-errors.md
+++ b/pointers-and-errors.md
@@ -121,7 +121,7 @@ func TestWallet(t *testing.T) {
 
 	got := wallet.Balance()
 
-	fmt.Printf("address of balance in test is %v \n", &wallet.balance)
+	fmt.Printf("address of balance in test is %p \n", &wallet.balance)
 
 	want := 10
 
@@ -133,7 +133,7 @@ func TestWallet(t *testing.T) {
 
 ```go
 func (w Wallet) Deposit(amount int) {
-	fmt.Printf("address of balance in Deposit is %v \n", &w.balance)
+	fmt.Printf("address of balance in Deposit is %p \n", &w.balance)
 	w.balance += amount
 }
 ```


### PR DESCRIPTION
After the Stringer interface is implemented `%v` will no longer print the memory address but instead will invoke the Stringer interface which is confusing. 

Using `%p` means it will consistently print the variable's memory address.