### PR TITLE
Fixes typo in test name

### DIFF
--- a/math.md
+++ b/math.md
@@ -575,7 +575,7 @@ for us to swallow.
 ### Write the test first
 
 ```go
-func TestSecondHandVector(t *testing.T) {
+func TestSecondHandPoint(t *testing.T) {
 	cases := []struct {
 		time  time.Time
 		point Point


### PR DESCRIPTION
The function name seems wrong in this part of the document, TestSecondHandPoint is used further in the document and is testing secondHandPoint.