### PR TITLE
use assertError for TestDelete

### DIFF
--- a/maps/v7/dictionary_test.go
+++ b/maps/v7/dictionary_test.go
@@ -74,9 +74,7 @@ func TestDelete(t *testing.T) {
 	dictionary.Delete(word)
 
 	_, err := dictionary.Search(word)
-	if err != ErrNotFound {
-		t.Errorf("Expected %q to be deleted", word)
-	}
+	assertError(t, err, ErrNotFound)
 }
 
 func assertStrings(t testing.TB, got, want string) {


### PR DESCRIPTION
Updating TestDelete to use `assertError(t, err, ErrNotFound)` so it is consistent with the rest of the tests.