### PR TITLE
Fine tune language, punctuation, and markdown formatting

### DIFF
--- a/generics.md
+++ b/generics.md
@@ -2,7 +2,7 @@
 
 **[You can find all the code for this chapter here](https://github.com/quii/learn-go-with-tests/tree/main/generics)**
 
-This chapter will give you an introduction to generics, dispel reservations you may have about them and, give you an idea how to simplify some of your code in the future. After reading this you'll know how to write:
+This chapter will give you an introduction to generics, dispel reservations you may have about them, and give you an idea how to simplify some of your code in the future. After reading this you'll know how to write:
 
 - A function that takes generic arguments
 - A generic data-structure

--- a/mocking.md
+++ b/mocking.md
@@ -631,8 +631,8 @@ Martin Fowler.
 
 Once a developer learns about mocking it becomes very easy to over-test every single facet of a system in terms of the _way it works_ rather than _what it does_. Always be mindful about **the value of your tests** and what impact they would have in future refactoring.
 
-In this post about mocking we have only covered **Spies** which are a kind of mock. The "proper" term for mocks though are "test doubles"
+In this post about mocking we have only covered **Spies**, which are a kind of mock. Mocks are a type of "test double."
 
-[> Test Double is a generic term for any case where you replace a production object for testing purposes.](https://martinfowler.com/bliki/TestDouble.html)
+> [Test Double is a generic term for any case where you replace a production object for testing purposes.](https://martinfowler.com/bliki/TestDouble.html)
 
 Under test doubles, there are various types like stubs, spies and indeed mocks! Check out [Martin Fowler's post](https://martinfowler.com/bliki/TestDouble.html) for more detail.

--- a/mocking.md
+++ b/mocking.md
@@ -159,7 +159,7 @@ Go!`
 }
 ```
 
-The backtick syntax is another way of creating a `string` but lets you put things like newlines which is perfect for our test.
+The backtick syntax is another way of creating a `string` but lets you include things like newlines, which is perfect for our test.
 
 ## Try and run the test
 

--- a/reflection.md
+++ b/reflection.md
@@ -135,10 +135,10 @@ We need to use reflection to have a look at `x` and try and look at its properti
 
 The [reflect package](https://pkg.go.dev/reflect) has a function `ValueOf` which returns us a `Value` of a given variable. This has ways for us to inspect a value, including its fields which we use on the next line.
 
-We then make some very optimistic assumptions about the value passed in
+We then make some very optimistic assumptions about the value passed in:
 
-- We look at the first and only field, there may be no fields at all which would cause a panic
-- We then call `String()` which returns the underlying value as a string but we know it would be wrong if the field was something other than a string.
+- We look at the first and only field. However, there may be no fields at all, which would cause a panic.
+- We then call `String()`, which returns the underlying value as a string. However, this would be wrong if the field was something other than a string.
 
 ## Refactor
 

--- a/select.md
+++ b/select.md
@@ -189,7 +189,7 @@ We've refactored creating our fake servers into a function called `makeDelayedSe
 
 By prefixing a function call with `defer` it will now call that function _at the end of the containing function_.
 
-Sometimes you will need to cleanup resources, such as closing a file or in our case closing a server so that it does not continue to listen to a port.
+Sometimes you will need to clean up resources, such as closing a file or in our case closing a server so that it does not continue to listen to a port.
 
 You want this to execute at the end of the function, but keep the instruction near where you created the server for the benefit of future readers of the code.
 

--- a/sync.md
+++ b/sync.md
@@ -160,7 +160,7 @@ The test will _probably_ fail with a different number, but nonetheless it demons
 
 ## Write enough code to make it pass
 
-A simple solution is to add a lock to our `Counter`, a [`Mutex`](https://golang.org/pkg/sync/#Mutex)
+A simple solution is to add a lock to our `Counter`, ensuring only one goroutine can increment the counter at a time. Go's [`Mutex`](https://golang.org/pkg/sync/#Mutex) provides such a lock:
 
 >A Mutex is a mutual exclusion lock. The zero value for a Mutex is an unlocked mutex.
 


### PR DESCRIPTION
👋 Hello - thanks for maintaining `learn-go-with-tests`. This PR seeks to make a few tweaks...

* properly format the markdown blockquote and link at https://quii.gitbook.io/learn-go-with-tests/go-fundamentals/mocking#mocking-1
* fine tune some language to be a bit more clear
* include previously missing commas and periods
* correctly use the two word verb phrase "clean up" rather than the one-word noun ("cleanup")
* correct comma placement

If I'm not mistaken, there are a number of other similar grammar and spelling errors throughout `learn-go-with-tests` too. I've attempted to keep this PR relatively-ish small and easy to review, but if you're receptive to the changes, I'm happy to continue opening similar follow-on PRs (or to add additional commits to this PR, if you prefer).