### PR TITLE
Fix: corrected imports in code samples; corrected tree structures

### DIFF
--- a/scaling-acceptance-tests.md
+++ b/scaling-acceptance-tests.md
@@ -328,7 +328,7 @@ func TestGreeterServer(t *testing.T) {
 			Context:    "../../.",
 			Dockerfile: "./cmd/httpserver/Dockerfile",
 	  // set to false if you want less spam, but this is helpful if you're having troubles
-	  PrintBuildLog: true, 
+	  PrintBuildLog: true,
 		},
 	ExposedPorts: []string{"8080:8080"},
 		WaitingFor:   wait.ForHTTP("/").WithPort("8080"),
@@ -341,7 +341,7 @@ func TestGreeterServer(t *testing.T) {
 	t.Cleanup(func() {
 		assert.NoError(t, container.Terminate(ctx))
 	})
-	
+
 	driver := go_specs_greet.Driver{BaseURL: "http://localhost:8080"}
 	specifications.GreetSpecification(t, driver)
 }
@@ -662,7 +662,7 @@ func (g GreetAdapter) Greet(name string) (string, error) {
 We can now use our adapter in our test to plug our `Greet` function into the specification.
 
 ```go
-package main_test
+package go_specs_greet_test
 
 import (
 	"testing"
@@ -718,13 +718,16 @@ Sometimes, it makes sense to do some refactoring _before_ making a change.
 
 For that reason, let's move our `http` code - `driver.go` and `handler.go` - into a package called `httpserver` within an `adapters` folder and change their package names to `httpserver`.
 
-You'll now need to  import the root package into handler.go to refer to the Greet method...
+You'll now need to import the root package into handler.go to refer to the Greet method...
 
 ```go
 package httpserver
 
 import (
-	go_specs_greet "github.com/quii/go-specs-greet"
+    "fmt"
+    "net/http"
+
+    go_specs_greet "github.com/quii/go-specs-greet/domain/interactions"
 )
 
 func Handler(w http.ResponseWriter, r *http.Request) {
@@ -757,7 +760,7 @@ and update the import and reference to `Driver` in greeter_server_test.go:
 ```go
 import (
 	...
-	"github.com/quii/go-specs-greet/adapters/httpserver" 
+	"github.com/quii/go-specs-greet/adapters/httpserver"
 	...
 )
 
@@ -806,6 +809,7 @@ quii@Chriss-MacBook-Pro go-specs-greet % tree
 ├── go.mod
 ├── go.sum
 └── specifications
+    └── adapters.go
     └── greet.go
 
 ```
@@ -1056,7 +1060,7 @@ func (d Driver) Greet(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
 	return greeting.Message, nil
 }
 ```
@@ -1184,7 +1188,7 @@ func (d *Driver) Greet(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
 	return greeting.Message, nil
 }
 
@@ -1205,7 +1209,6 @@ Let's take a look at the current state of our project structure before moving on
 ```
 quii@Chriss-MacBook-Pro go-specs-greet % tree
 .
-├── Dockerfile
 ├── Makefile
 ├── README.md
 ├── adapters
@@ -1221,9 +1224,11 @@ quii@Chriss-MacBook-Pro go-specs-greet % tree
 │       └── handler.go
 ├── cmd
 │   ├── grpcserver
+│   │   ├── Dockerfile
 │   │   ├── greeter_server_test.go
 │   │   └── main.go
 │   └── httpserver
+│       ├── Dockerfile
 │       ├── greeter_server_test.go
 │       └── main.go
 ├── domain
@@ -1466,7 +1471,7 @@ func (d *Driver) Curse(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	
+
 	return greeting.Message, nil
 }
 ```
@@ -1552,6 +1557,6 @@ Specifications should then double up as documentation. They should specify clear
 - In this example, our "DSL" is not much of a DSL; we just used interfaces to decouple our specification from the real world and allow us to express domain logic cleanly. As your system grows, this level of abstraction might become clumsy and unclear. [Read into the "Screenplay Pattern"](https://cucumber.io/blog/bdd/understanding-screenplay-(part-1)/) if you want to find more ideas as to how to structure your specifications.
 - For emphasis, [Growing Object-Oriented Software, Guided by Tests,](http://www.growing-object-oriented-software.com) is a classic. It demonstrates applying this "London style", "top-down" approach to writing software. Anyone who has enjoyed Learn Go with Tests should get much value from reading GOOS.
 - [In the example code repository](https://github.com/quii/go-specs-greet), there's more code and ideas I haven't written about here, such as multi-stage docker build, you may wish to check this out.
-  - In particular, *for fun*, I made a **third program**, a website with some HTML forms to `Greet` and `Curse`. The `Driver` leverages the excellent-looking [https://github.com/go-rod/rod](https://github.com/go-rod/rod) module, which allows it to work with the website with a browser, just like a user would. Looking at the git history, you can see how I started not using any templating tools "just to make it work" Then, once I passed my acceptance test, I had the freedom to do so without fear of breaking things. 
+  - In particular, *for fun*, I made a **third program**, a website with some HTML forms to `Greet` and `Curse`. The `Driver` leverages the excellent-looking [https://github.com/go-rod/rod](https://github.com/go-rod/rod) module, which allows it to work with the website with a browser, just like a user would. Looking at the git history, you can see how I started not using any templating tools "just to make it work" Then, once I passed my acceptance test, I had the freedom to do so without fear of breaking things.
 
 

--- a/scaling-acceptance-tests.md
+++ b/scaling-acceptance-tests.md
@@ -543,7 +543,7 @@ The change in the specification has meant our driver needs to be updated.
 
 ## Write the minimal amount of code for the test to run and check the failing test output
 
-Update the driver so it specifies a `name` query value in the request to ask for a particular `name` to be greeted.
+Update the driver so that it specifies a `name` query value in the request to ask for a particular `name` to be greeted.
 
 ```go
 func (d Driver) Greet(name string) (string, error) {
@@ -718,7 +718,7 @@ Sometimes, it makes sense to do some refactoring _before_ making a change.
 
 For that reason, let's move our `http` code - `driver.go` and `handler.go` - into a package called `httpserver` within an `adapters` folder and change their package names to `httpserver`.
 
-You'll now need to import the root package into handler.go to refer to the Greet method...
+You'll now need to import the root package into `handler.go` to refer to the Greet method...
 
 ```go
 package httpserver
@@ -737,7 +737,7 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 
 ```
 
-import your httpserver adapater into main.go:
+import your httpserver adapter into main.go:
 
 ```go
 package main
@@ -1372,7 +1372,7 @@ Let's extend our API to include a "curse" functionality.
 
 ## Write the test first
 
-This is brand new behaviour so we should start with an acceptance test. In our specification file, add the following
+This is brand-new behaviour, so we should start with an acceptance test. In our specification file, add the following
 
 ```go
 type MeanGreeter interface {
@@ -1444,7 +1444,7 @@ service Greeter {
 }
 ```
 
-You could argue that reusing the types `GreetRequest` and `GreetReply` is inappropriate coupling, but we can deal with that in the refactoring stage. As I keep stressing, we're just trying to get the test passing so we verify the software works, _then_ we can make it nice.
+You could argue that reusing the types `GreetRequest` and `GreetReply` is inappropriate coupling, but we can deal with that in the refactoring stage. As I keep stressing, we're just trying to get the test passing, so we verify the software works, _then_ we can make it nice.
 
 Re-generate our code with (inside `adapters/grpcserver`).
 


### PR DESCRIPTION
As I was going through [Scaling acceptance tests](https://quii.gitbook.io/learn-go-with-tests/testing-fundamentals/scaling-acceptance-tests), I updated the code sample imports and tree structures to reflect the current state the code seemed to be in. 