### PR TITLE
fix(maps): remove unreachable code

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -417,15 +417,13 @@ func (d Dictionary) Add(word, definition string) error {
 		d[word] = definition
 	case nil:
 		return ErrWordExists
-	default:
-		return err
 	}
 
-	return nil
+	return err
 }
 ```
 
-Here we are using a `switch` statement to match on the error. Having a `switch` like this provides an extra safety net, in case `Search` returns an error other than `ErrNotFound`.
+Here we are using a `switch` statement to match on the error. We return the error as it is in case `Search` returns an error other than `ErrNotFound` and does not match any case of our `switch` statement.
 
 ## Refactor
 

--- a/maps/v4/dictionary.go
+++ b/maps/v4/dictionary.go
@@ -36,10 +36,7 @@ func (d Dictionary) Add(word, definition string) error {
 		d[word] = definition
 	case nil:
 		return ErrWordExists
-	default:
-		return err
-
 	}
 
-	return nil
+	return err
 }

--- a/maps/v5/dictionary.go
+++ b/maps/v5/dictionary.go
@@ -36,12 +36,9 @@ func (d Dictionary) Add(word, definition string) error {
 		d[word] = definition
 	case nil:
 		return ErrWordExists
-	default:
-		return err
-
 	}
 
-	return nil
+	return err
 }
 
 // Update changes the definition of a given word.

--- a/maps/v6/dictionary.go
+++ b/maps/v6/dictionary.go
@@ -39,12 +39,9 @@ func (d Dictionary) Add(word, definition string) error {
 		d[word] = definition
 	case nil:
 		return ErrWordExists
-	default:
-		return err
-
 	}
 
-	return nil
+	return err
 }
 
 // Update changes the definition of a given word.

--- a/maps/v7/dictionary.go
+++ b/maps/v7/dictionary.go
@@ -39,12 +39,9 @@ func (d Dictionary) Add(word, definition string) error {
 		d[word] = definition
 	case nil:
 		return ErrWordExists
-	default:
-		return err
-
 	}
 
-	return nil
+	return err
 }
 
 // Update changes the definition of a given word.


### PR DESCRIPTION
Using a `default` clause on the `switch` statement forces us to return something in the end of the function only to satisfy the compiler, as we are writing unreachable code.