### PR TITLE
Move test refactoring to after tests pass

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -263,13 +263,26 @@ Here we are introducing another tool in our testing arsenal, subtests. Sometimes
 
 A benefit of this approach is you can set up shared code that can be used in the other tests.
 
-There is repeated code when we check if the message is what we expect.
+While we have a failing test, let's fix the code, using an `if`.
+
+```go
+const englishHelloPrefix = "Hello, "
+
+func Hello(name string) string {
+	if name == "" {
+		name = "World"
+	}
+	return englishHelloPrefix + name
+}
+```
+
+If we run our tests we should see it satisfies the new requirement and we haven't accidentally broken the other functionality.
+
+It is important that your tests _are clear specifications_ of what the code needs to do. But there is repeated code when we check if the message is what we expect.
 
 Refactoring is not _just_ for the production code!
 
-It is important that your tests _are clear specifications_ of what the code needs to do.
-
-We can and should refactor our tests.
+Now that the tests are passing, we can and should refactor our tests.
 
 ```go
 func TestHello(t *testing.T) {
@@ -303,25 +316,9 @@ For helper functions, it's a good idea to accept a `testing.TB` which is an inte
 
 `t.Helper()` is needed to tell the test suite that this method is a helper. By doing this when it fails the line number reported will be in our _function call_ rather than inside our test helper. This will help other developers track down problems easier. If you still don't understand, comment it out, make a test fail and observe the test output. Comments in Go are a great way to add additional information to your code, or in this case, a quick way to tell the compiler to ignore a line. You can comment out the `t.Helper()` code by adding two forward slashes `//` at the beginning of the line. You should see that line turn grey or change to another color than the rest of your code to indicate it's now commented out.
 
-Now that we have a well-written failing test, let's fix the code, using an `if`.
-
-```go
-const englishHelloPrefix = "Hello, "
-
-func Hello(name string) string {
-	if name == "" {
-		name = "World"
-	}
-	return englishHelloPrefix + name
-}
-```
-
-If we run our tests we should see it satisfies the new requirement and we haven't accidentally broken the other functionality.
-
 ### Back to source control
 
-Now we are happy with the code I would amend the previous commit so we only
-check in the lovely version of our code with its test.
+Now we are happy with the code I would amend the previous commit so we only check in the lovely version of our code with its test.
 
 ### Discipline
 


### PR DESCRIPTION
We were refactoring the subtest helper method while one subtest was still failing. I've moved the refactor down so we fix the failing test first, then refactor.