### PR TITLE
fix: hello-world.md in switch cases language starts with capital letter

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -462,9 +462,9 @@ func Hello(name string, language string) string {
 	prefix := englishHelloPrefix
 
 	switch language {
-	case "french":
+	case "French":
 		prefix = frenchHelloPrefix
-	case "spanish":
+	case "Spanish":
 		prefix = spanishHelloPrefix
 	}
 


### PR DESCRIPTION
Fixes switch statement example from [hello-world.md](https://github.com/quii/learn-go-with-tests/blob/main/hello-world.md#switch).
Right now switch cases are non capitalized which will lead to failed tests, code expects language string like "French" and not "french". That mistake not covered in book, so I assume it's just a mistake and not an example of any sort.