### PR TITLE
remove unnecessary plus flag for slice output format

### DIFF
--- a/reflection.md
+++ b/reflection.md
@@ -770,7 +770,7 @@ func assertContains(t testing.TB, haystack []string, needle string) {
 		}
 	}
 	if !contains {
-		t.Errorf("expected %+v to contain %q but it didn't", haystack, needle)
+		t.Errorf("expected %v to contain %q but it didn't", haystack, needle)
 	}
 }
 ```

--- a/reflection/v10/reflection_test.go
+++ b/reflection/v10/reflection_test.go
@@ -154,6 +154,6 @@ func assertContains(t testing.TB, haystack []string, needle string) {
 		}
 	}
 	if !contains {
-		t.Errorf("expected %+v to contain %q but it didn't", haystack, needle)
+		t.Errorf("expected %v to contain %q but it didn't", haystack, needle)
 	}
 }

--- a/reflection/v8/reflection_test.go
+++ b/reflection/v8/reflection_test.go
@@ -115,6 +115,6 @@ func assertContains(t testing.TB, haystack []string, needle string) {
 		}
 	}
 	if !contains {
-		t.Errorf("expected %+v to contain %q but it didn't", haystack, needle)
+		t.Errorf("expected %v to contain %q but it didn't", haystack, needle)
 	}
 }

--- a/reflection/v9/reflection_test.go
+++ b/reflection/v9/reflection_test.go
@@ -136,6 +136,6 @@ func assertContains(t testing.TB, haystack []string, needle string) {
 		}
 	}
 	if !contains {
-		t.Errorf("expected %+v to contain %q but it didn't", haystack, needle)
+		t.Errorf("expected %v to contain %q but it didn't", haystack, needle)
 	}
 }


### PR DESCRIPTION
Removes unnecessary + flag from format string, it doesn't affect output for slices.