### PR TITLE
Fix parameter type typo in arrays guide

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -510,7 +510,7 @@ Our tests have some repeated code around the assertions again, so let's extract 
 ```go
 func TestSumAllTails(t *testing.T) {
 
-	checkSums := func(t testing.TB, got, want []int) {
+	checkSums := func(t testing.T, got, want []int) {
 		t.Helper()
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v want %v", got, want)

--- a/structs-methods-and-interfaces.md
+++ b/structs-methods-and-interfaces.md
@@ -334,7 +334,7 @@ Let's introduce this by refactoring our tests.
 ```go
 func TestArea(t *testing.T) {
 
-	checkArea := func(t testing.TB, shape Shape, want float64) {
+	checkArea := func(t testing.T, shape Shape, want float64) {
 		t.Helper()
 		got := shape.Area()
 		if got != want {


### PR DESCRIPTION
Found two typos, it won't compile for `*testing.TB` -> `t.Errorf undefined (type *testing.TB is pointer to interface, not interface)`