### PR TITLE
Handle the error returned by our updated Racer function

### DIFF
--- a/select.md
+++ b/select.md
@@ -257,22 +257,48 @@ Our final requirement was to return an error if `Racer` takes longer than 10 sec
 ## Write the test first
 
 ```go
-t.Run("returns an error if a server doesn't respond within 10s", func(t *testing.T) {
-	serverA := makeDelayedServer(11 * time.Second)
-	serverB := makeDelayedServer(12 * time.Second)
+func TestRacer(t *testing.T) {
 
-	defer serverA.Close()
-	defer serverB.Close()
+	t.Run("compares speeds of servers, returning the url of the fastest one", func(t *testing.T) {
+		slowServer := makeDelayedServer(20 * time.Millisecond)
+		fastServer := makeDelayedServer(0 * time.Millisecond)
 
-	_, err := Racer(serverA.URL, serverB.URL)
+		defer slowServer.Close()
+		defer fastServer.Close()
 
-	if err == nil {
-		t.Error("expected an error but didn't get one")
-	}
-})
+		slowURL := slowServer.URL
+		fastURL := fastServer.URL
+
+		want := fastURL
+		got, _ := Racer(slowURL, fastURL)
+
+		if err != nil {
+			t.Fatalf("did not expect an error but got one %v", err)
+		}
+
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns an error if a server doesn't respond within 10s", func(t *testing.T) {
+		serverA := makeDelayedServer(11 * time.Second)
+		serverB := makeDelayedServer(12 * time.Second)
+
+		defer serverA.Close()
+		defer serverB.Close()
+
+		_, err := Racer(serverA.URL, serverB.URL)
+
+		if err == nil {
+			t.Error("expected an error but didn't get one")
+		}
+	})
 ```
 
 We've made our test servers take longer than 10s to return to exercise this scenario and we are expecting `Racer` to return two values now, the winning URL (which we ignore in this test with `_`) and an `error`.
+
+Note that we've also handled the error return in our original test, we're using	`_` for now to ensure the tests will run.
 
 ## Try to run the test
 


### PR DESCRIPTION
 In the Select chapter, after adding the `error` in the return from `Racer` we need to also update our original test to handle the error, else when we run the tests we will see:

```sh
/racer_test.go:24:16: assignment mismatch: 1 variable but Racer returns 2 values
```


Given we do nothing with it until later on, handling with `_` makes the most sense.

I've included the initial test in full to demonstrate the change, and added a note for the reader to explain why this change needs to be made.