### PR TITLE
tidy up project references

### DIFF
--- a/math.md
+++ b/math.md
@@ -193,7 +193,7 @@ and now we get:
     clockface_test.go:17: Got {0 0}, wanted {150 60}
 FAIL
 exit status 1
-FAIL	github.com/gypsydave5/learn-go-with-tests/math/v1/clockface	0.006s
+FAIL	learn-go-with-tests/math/clockface	0.006s
 ```
 
 ### Write enough code to make it pass
@@ -857,7 +857,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/quii/learn-go-with-tests/math/clockface" // REPLACE THIS!
+	"learn-go-with-tests/math/clockface" // REPLACE THIS!
 )
 
 func main() {
@@ -1133,7 +1133,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/gypsydave5/learn-go-with-tests/math/v7b/clockface"
+	"learn-go-with-tests/math/clockface"
 )
 
 func main() {
@@ -1829,7 +1829,7 @@ get the remainder of the current hour divided by 12.
 
 ```
 PASS
-ok  	github.com/gypsydave5/learn-go-with-tests/math/v10/clockface	0.008s
+ok  	learn-go-with-tests/math/clockface	0.008s
 ```
 ### Write the test first
 
@@ -2006,7 +2006,7 @@ The tests will soon tell me if I'm wrong.
 
 ```
 PASS
-ok  	github.com/gypsydave5/learn-go-with-tests/math/v11/clockface	0.009s
+ok  	learn-go-with-tests/math/clockface	0.009s
 ```
 <!--
 Here endeth v11


### PR DESCRIPTION
I've removed Dave and Chris' usernames from the project references so that any mention of the project path is a bit cleaner, eg. in quoted failure messages it will read learn-go-with-tests/math/clockface