### PR TITLE
at this stage we purposely ignore error with blank identifier

### DIFF
--- a/select.md
+++ b/select.md
@@ -272,10 +272,6 @@ func TestRacer(t *testing.T) {
 		want := fastURL
 		got, _ := Racer(slowURL, fastURL)
 
-		if err != nil {
-			t.Fatalf("did not expect an error but got one %v", err)
-		}
-
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)
 		}


### PR DESCRIPTION
The error is handled properly [a little bit after](https://github.com/quii/learn-go-with-tests/blob/main/select.md?plain=1#L416) in the document 