### PR TITLE
Added missing return statement to pointers-and-errors.md

### DIFF
--- a/pointers-and-errors.md
+++ b/pointers-and-errors.md
@@ -88,6 +88,7 @@ Remember we can access the internal `balance` field in the struct using the "rec
 ```go
 func (w Wallet) Deposit(amount int) {
 	w.balance += amount
+    return w.balance
 }
 
 func (w Wallet) Balance() int {


### PR DESCRIPTION
The code does not return the expected result, instead it throws a a different error:

# learn-go-with-tests/pointers [learn-go-with-tests/pointers.test] ./wallet.go:10:1: missing return
FAIL    learn-go-with-tests/pointers [build failed]