### PR TITLE
fix(math): clarify which test file to use

### DIFF
--- a/math.md
+++ b/math.md
@@ -1015,7 +1015,7 @@ type Svg struct {
 
 We could make adjustments to this if we needed to (like changing the name of the
 struct to `SVG`) but it's definitely good enough to start us off. Paste the
-struct into the `clockface_assembly_test` file and let's write a test with it:
+struct into the `clockface_acceptance_test` file and let's write a test with it:
 
 ```go
 func TestSVGWriterAtMidnight(t *testing.T) {


### PR DESCRIPTION
A section of the math chapter says to add an Svg struct to a `clockface_assembly_test` file, but that's not the name of a test file that's used in the clockface example. Because the next state of the code (v7b) shows that struct (and the corresponding code) in the `clockface_acceptance_test` file, this MR updates the name of the mentioned test file from `clockface_assembly_test` to `clockface_acceptance_test`.