### PR TITLE
fixed passing wrong interface type in the checkSums function

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -510,7 +510,7 @@ Our tests have some repeated code around the assertions again, so let's extract 
 ```go
 func TestSumAllTails(t *testing.T) {
 
-	checkSums := func(t testing.TB, got, want []int) {
+	checkSums := func(t testing.T, got, want []int) {
 		t.Helper()
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got %v want %v", got, want)


### PR DESCRIPTION
The errors: 
![image](https://github.com/quii/learn-go-with-tests/assets/37550706/8483bd5c-1f09-498c-8707-e3b53a599321)

After changing the checkSums's interface to match the parent's function t parameter type it works and passes all tests.
