### PR TITLE
Use current pandoc/latex image to generate epub

### DIFF
--- a/build.books.sh
+++ b/build.books.sh
@@ -43,7 +43,7 @@ docker run --rm -v `pwd`:/data uppalabharath/pandoc-latex-cjk:latest --from=gfm+
     http-handlers-revisited.md \
     anti-patterns.md
 
-docker run --rm -v `pwd`:/data uppalabharath/pandoc-latex-cjk:latest --from=gfm+rebase_relative_paths --to=epub --file-scope title.txt -o learn-go-with-tests.epub --pdf-engine=xelatex --toc --toc-depth=1  \
+docker run --rm -v `pwd`:/data pandoc/latex:latest --from=gfm+rebase_relative_paths --to=epub --file-scope title.txt -o learn-go-with-tests.epub --pdf-engine=xelatex --toc --toc-depth=1  \
     gb-readme.md \
     why.md \
     hello-world.md \


### PR DESCRIPTION
## Overview

Replace use of older `uppalabharath/pandoc-latex-cjk:latest` image with `pandoc/latex:edge-ubuntu`.

At present the older image is from November 2021 and contains Pandoc 2.16.1, whereas the `pandoc/latex:edge-ubuntu` image is from March 2023 and provides Pandoc 3.1.1.

epub files generated using this newer image successfully import into Google Play Books without error.

## References

- GH-598