### PR TITLE
Enable misspell and gofmtmd; fix formatting issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,17 +3,16 @@
 set -e
 
 go get github.com/gorilla/websocket #todo vendor this or learn about the module stuff!
-#go get -u golang.org/x/lint/golint
-#go get -u github.com/client9/misspell/cmd/misspell
-#go get github.com/po3rin/gofmtmd/cmd/gofmtmd
+go install github.com/client9/misspell/cmd/misspell@latest
+go install github.com/po3rin/gofmtmd/cmd/gofmtmd@latest
 
-#ls *.md | xargs misspell -error
-#for md_file in ./*.md; do
-#    echo "formatting  file: $md_file"
-#    gofmtmd "$md_file" -r
-#done
+ls *.md | xargs misspell -error
+
+for md_file in ./*.md; do
+    echo "formatting  file: $md_file"
+    gofmtmd  "$md_file" -r
+done
 
 go test ./...
 go vet ./...
 go fmt ./...
-#golint ./...

--- a/command-line.md
+++ b/command-line.md
@@ -68,7 +68,7 @@ Finally, we need to import this package into `main.go` so we can use it to creat
 The paths will be different on your computer, but it should be similar to this:
 
 ```go
-//cmd/webserver/main.go
+// cmd/webserver/main.go
 package main
 
 import (
@@ -116,7 +116,7 @@ In addition, users can view [the documentation at pkg.go.dev](https://pkg.go.dev
 Before we get stuck into writing tests, let's add a new application that our project will build. Create another directory inside `cmd` called `cli` (command line interface) and add a `main.go` with the following
 
 ```go
-//cmd/cli/main.go
+// cmd/cli/main.go
 package main
 
 import "fmt"
@@ -137,7 +137,7 @@ Before we jump too far ahead though, let's just write a test to check it integra
 Inside `CLI_test.go` (in the root of the project, not inside `cmd`)
 
 ```go
-//CLI_test.go
+// CLI_test.go
 package poker
 
 import "testing"
@@ -172,7 +172,7 @@ At this point, you should be comfortable enough to create our new `CLI` struct w
 You should end up with code like this
 
 ```go
-//CLI.go
+// CLI.go
 package poker
 
 type CLI struct {
@@ -464,7 +464,7 @@ Anecdotally I have used this technique in other shared packages and it has prove
 So let's create a file called `testing.go` and add our stub and our helpers.
 
 ```go
-//testing.go
+// testing.go
 package poker
 
 import "testing"
@@ -622,7 +622,7 @@ Now refactor both of our applications to use this function to create the store.
 #### CLI application code
 
 ```go
-//cmd/cli/main.go
+// cmd/cli/main.go
 package main
 
 import (
@@ -651,7 +651,7 @@ func main() {
 #### Web server application code
 
 ```go
-//cmd/webserver/main.go
+// cmd/webserver/main.go
 package main
 
 import (

--- a/generics.md
+++ b/generics.md
@@ -437,7 +437,7 @@ func (s *Stack[T]) Push(value T) {
 }
 
 func (s *Stack[T]) IsEmpty() bool {
-	return len(s.values)==0
+	return len(s.values) == 0
 }
 
 func (s *Stack[T]) Pop() (T, bool) {
@@ -446,7 +446,7 @@ func (s *Stack[T]) Pop() (T, bool) {
 		return zero, false
 	}
 
-	index := len(s.values) -1
+	index := len(s.values) - 1
 	el := s.values[index]
 	s.values = s.values[:index]
 	return el, true

--- a/hello-world.md
+++ b/hello-world.md
@@ -409,20 +409,20 @@ The tests should now pass.
 Now it is time to _refactor_. You should see some problems in the code, "magic" strings, some of which are repeated. Try and refactor it yourself, with every change make sure you re-run the tests to make sure your refactoring isn't breaking anything.
 
 ```go
-    const spanish = "Spanish"
-    const englishHelloPrefix = "Hello, "
-    const spanishHelloPrefix = "Hola, "
+	const spanish = "Spanish"
+	const englishHelloPrefix = "Hello, "
+	const spanishHelloPrefix = "Hola, "
 
-func Hello(name string, language string) string {
-	if name == "" {
-		name = "World"
-	}
+	func Hello(name string, language string) string {
+		if name == "" {
+			name = "World"
+		}
 
-	if language == spanish {
-		return spanishHelloPrefix + name
+		if language == spanish {
+			return spanishHelloPrefix + name
+		}
+		return englishHelloPrefix + name
 	}
-	return englishHelloPrefix + name
-}
 ```
 
 ### French
@@ -483,10 +483,10 @@ You could argue that maybe our function is getting a little big. The simplest re
 const (
 	french  = "French"
 	spanish = "Spanish"
-    
-    englishHelloPrefix = "Hello, "
-    spanishHelloPrefix = "Hola, "
-    frenchHelloPrefix = "Bonjour, "
+
+	englishHelloPrefix = "Hello, "
+	spanishHelloPrefix = "Hola, "
+	frenchHelloPrefix  = "Bonjour, "
 )
 
 func Hello(name string, language string) string {

--- a/html-templates.md
+++ b/html-templates.md
@@ -531,7 +531,7 @@ func Render(w io.Writer, p Post) error {
 		return err
 	}
 
-    if err := templ.ExecuteTemplate(w, "blog.gohtml", p); err != nil {
+	if err := templ.ExecuteTemplate(w, "blog.gohtml", p); err != nil {
 		return err
 	}
 
@@ -588,7 +588,7 @@ func NewPostRenderer() (*PostRenderer, error) {
 
 func (r *PostRenderer) Render(w io.Writer, p Post) error {
 
-    if err := r.templ.ExecuteTemplate(w, "blog.gohtml", p); err != nil {
+	if err := r.templ.ExecuteTemplate(w, "blog.gohtml", p); err != nil {
 		return err
 	}
 

--- a/http-server.md
+++ b/http-server.md
@@ -959,7 +959,7 @@ For that reason, it is recommended that you research _The Test Pyramid_.
 In the interest of brevity, I am going to show you the final refactored integration test.
 
 ```go
-//server_integration_test.go
+// server_integration_test.go
 package main
 
 import (
@@ -1035,7 +1035,7 @@ func (i *InMemoryPlayerStore) GetPlayerScore(name string) int {
 The integration test passes, now we just need to change `main` to use `NewInMemoryPlayerStore()`
 
 ```go
-//main.go
+// main.go
 package main
 
 import (

--- a/intro-to-acceptance-tests.md
+++ b/intro-to-acceptance-tests.md
@@ -254,13 +254,13 @@ func waitForServerListening(port string) error {
 }
 
 func randomString(n int) string {
-    var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
-    s := make([]rune, n)
-    for i := range s {
-        s[i] = letters[rand.Intn(len(letters))]
-    }
-    return string(s)
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(s)
 }
 ```
 
@@ -294,7 +294,7 @@ import (
 
 const (
 	port = "8080"
-	url  = "<http://localhost:"> + port
+	url  = "<http://localhost:" > +port
 )
 
 func TestGracefulShutdown(t *testing.T) {

--- a/io.md
+++ b/io.md
@@ -718,7 +718,7 @@ store := &FileSystemPlayerStore{database}
 If you run the test it should pass and now we can delete `InMemoryPlayerStore`. `main.go` will now have compilation problems which will motivate us to now use our new store in the "real" code.
 
 ```go
-//main.go
+// main.go
 package main
 
 import (
@@ -822,7 +822,7 @@ How will we test for this though? What we need to do is first refactor our code 
 We'll create a new type to encapsulate our "when we write we go from the beginning" functionality. I'm going to call it `Tape`. Create a new file with the following:
 
 ```go
-//tape.go
+// tape.go
 package main
 
 import "io"

--- a/math.md
+++ b/math.md
@@ -131,7 +131,7 @@ So my first test looks like this:
 package clockface_test
 
 import (
-    "projectpath/clockface"
+	"projectpath/clockface"
 	"testing"
 	"time"
 )
@@ -1068,7 +1068,7 @@ const (
 	clockCentreY     = 150
 )
 
-//SVGWriter writes an SVG representation of an analogue clock, showing the time t, to the writer w
+// SVGWriter writes an SVG representation of an analogue clock, showing the time t, to the writer w
 func SVGWriter(w io.Writer, t time.Time) {
 	io.WriteString(w, svgStart)
 	io.WriteString(w, bezel)
@@ -2073,7 +2073,7 @@ const (
 	clockCentreY     = 150
 )
 
-//SVGWriter writes an SVG representation of an analogue clock, showing the time t, to the writer w
+// SVGWriter writes an SVG representation of an analogue clock, showing the time t, to the writer w
 func SVGWriter(w io.Writer, t time.Time) {
 	io.WriteString(w, svgStart)
 	io.WriteString(w, bezel)

--- a/reflection.md
+++ b/reflection.md
@@ -744,7 +744,7 @@ To fix this, we'll need to move our assertion with the maps to a new test where 
 ```go
 t.Run("with maps", func(t *testing.T) {
 	aMap := map[string]string{
-		"Cow": "Moo",
+		"Cow":   "Moo",
 		"Sheep": "Baa",
 	}
 

--- a/roman-numerals.md
+++ b/roman-numerals.md
@@ -1176,13 +1176,13 @@ chapter so, in the interests of full disclosure, here's what he said.
 > sometimes `arabic` will be written as a decimal integer literal
 >
 > ```go
->   ConvertToRoman(255)
+> 	ConvertToRoman(255)
 > ```
 >
 > But it could just as well be written
 >
 > ```go
->   ConvertToRoman(0xFF)
+> 	ConvertToRoman(0xFF)
 > ```
 >
 > Really, we're not 'converting' from an Arabic numeral at all, we're 'printing'  -

--- a/select.md
+++ b/select.md
@@ -1,6 +1,6 @@
 # Select
 
-**[You can find all the code for this chapter here](https://github.com/quii/learn-go-with-tests/tree/main/select)**
+**[You can find all the code for this chapter here](https://github.com/quii/learn-go-with-tests/tree/main/reflection)**
 
 You have been asked to make a function called `WebsiteRacer` which takes two URLs and "races" them by hitting them with an HTTP GET and returning the URL which returned first. If none of them return within 10 seconds then it should return an `error`.
 
@@ -258,7 +258,6 @@ Our final requirement was to return an error if `Racer` takes longer than 10 sec
 
 ```go
 func TestRacer(t *testing.T) {
-
 	t.Run("compares speeds of servers, returning the url of the fastest one", func(t *testing.T) {
 		slowServer := makeDelayedServer(20 * time.Millisecond)
 		fastServer := makeDelayedServer(0 * time.Millisecond)
@@ -290,6 +289,7 @@ func TestRacer(t *testing.T) {
 			t.Error("expected an error but didn't get one")
 		}
 	})
+}
 ```
 
 We've made our test servers take longer than 10s to return to exercise this scenario and we are expecting `Racer` to return two values now, the winning URL (which we ignore in this test with `_`) and an `error`.


### PR DESCRIPTION
This PR enables `misspell` and `gofmtmd` linters in the `build.sh`. Also, formats md-files.

`golint` is deprecated. So, no need to enable it.