### PR TITLE
build.sh: remove unnecessary go get and resolve TODO

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-go get github.com/gorilla/websocket #todo vendor this or learn about the module stuff!
 go install github.com/client9/misspell/cmd/misspell@latest
 go install github.com/po3rin/gofmtmd/cmd/gofmtmd@latest
 


### PR DESCRIPTION
Because `github.com/gorilla/websocket` already present in the [go.mod](https://github.com/quii/learn-go-with-tests/blob/main/go.mod).