### PR TITLE
add info about `// Output:` comment syntax speciality

### DIFF
--- a/integers.md
+++ b/integers.md
@@ -148,7 +148,7 @@ $ go test -v
 --- PASS: ExampleAdd (0.00s)
 ```
 
-Please note that the example function will not be executed if you remove the comment `// Output: 6`. Although the function will be compiled, it won't be executed.
+Please note that the example function will not be executed if you remove the comment `// Output: 6`. Although the function will be compiled, it won't be executed. The `// Output:` comment embedded within an Example function is a special type of comment and deviation from the syntax will act as if the Output comment has been removed.
 
 By adding this code the example will appear in the documentation inside `godoc`, making your code even more accessible.
 

--- a/integers.md
+++ b/integers.md
@@ -148,7 +148,7 @@ $ go test -v
 --- PASS: ExampleAdd (0.00s)
 ```
 
-Please note that the example function will not be executed if you remove the comment `// Output: 6`. Although the function will be compiled, it won't be executed. The `// Output:` comment embedded within an Example function is a special type of comment and deviation from the syntax will act as if the Output comment has been removed.
+Please note that the example function will not be executed if you remove the comment `// Output: 6`. Although the function will be compiled, it won't be executed. The `// Output:` comment embedded within an example function is a special type of comment and deviation from the syntax will act as if the Output comment has been removed.
 
 By adding this code the example will appear in the documentation inside `godoc`, making your code even more accessible.
 


### PR DESCRIPTION
Feel free to laugh at me and kill the request, as I'm very new to Go and still learning. Modified integers.md to explain that `// Output:` is a special type of comment within an example function, which was very confusing as a beginner and even the blog link wasn't very clear of this.

I know it's a tiny change, but figured a beginner's perspective would at least be helpful.