### PR TITLE
Update arrays-and-slices.md - added slices package tip

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -336,7 +336,8 @@ func TestSumAll(t *testing.T) {
 What we have done here is try to compare a `slice` with a `string`. This makes
 no sense, but the test compiles! So while using `reflect.DeepEqual` is
 a convenient way of comparing slices \(and other things\) you must be careful
-when using it.
+when using it.  
+(From Go 1.21, [slices](https://pkg.go.dev/slices#pkg-overview) standard package is available, which has [slices.Equal](https://pkg.go.dev/slices#Equal) function to do a simple shallow compare on slices, where you don't need to worry about the types like the above case.)  
 
 Change the test back again and run it. You should have test output like the following
 


### PR DESCRIPTION
Added a line telling about the new "slices" package available from Go 1.21 which has slices.Equal, and that it has no issues with type