### PR TITLE
Update arrays-and-slices.md: Improved slices package tip with comparable

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -336,8 +336,9 @@ func TestSumAll(t *testing.T) {
 What we have done here is try to compare a `slice` with a `string`. This makes
 no sense, but the test compiles! So while using `reflect.DeepEqual` is
 a convenient way of comparing slices \(and other things\) you must be careful
-when using it.  
-(From Go 1.21, [slices](https://pkg.go.dev/slices#pkg-overview) standard package is available, which has [slices.Equal](https://pkg.go.dev/slices#Equal) function to do a simple shallow compare on slices, where you don't need to worry about the types like the above case.)  
+when using it.
+
+(From Go 1.21, [slices](https://pkg.go.dev/slices#pkg-overview) standard package is available, which has [slices.Equal](https://pkg.go.dev/slices#Equal) function to do a simple shallow compare on slices, where you don't need to worry about the types like the above case. Note that this function expects the elements to be [comparable](https://pkg.go.dev/builtin#comparable). So, it can't be applied to slices with non-comparable elements like 2D slices.)  
 
 Change the test back again and run it. You should have test output like the following
 


### PR DESCRIPTION
Added line to explain that the slices.Equal function expects the slice elements to be comparable

Ref: https://github.com/quii/learn-go-with-tests/pull/722#issuecomment-1862422513