### PR TITLE
fix typo in integers.md

### DIFF
--- a/integers.md
+++ b/integers.md
@@ -39,7 +39,7 @@ func TestAdder(t *testing.T) {
 }
 ```
 
-You will notice that we're using `%d` as our format strings rather than `%q`. That's because we want it to print an integer rather than a string.
+You will notice that we're using `%d` as our format strings rather than `%s`. That's because we want it to print an integer rather than a string.
 
 Also note that we are no longer using the main package, instead we've defined a package named `integers`, as the name suggests this will group functions for working with integers such as `Add`.
 


### PR DESCRIPTION
a small typo error changed %q  to %s in line 42