### PR TITLE
refactor: using assertError function on TestDelete of maps section

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -599,9 +599,7 @@ func TestDelete(t *testing.T) {
 	dictionary.Delete(word)
 
 	_, err := dictionary.Search(word)
-	if err != ErrNotFound {
-		t.Errorf("Expected %q to be deleted", word)
-	}
+    assertError(t, word, ErrNotFound)
 }
 ```
 


### PR DESCRIPTION
The previous tests from maps was using `assertError` but this one doesn't