### PR TITLE
Simplified ConvertToArabic algorithm

### DIFF
--- a/roman-numerals.md
+++ b/roman-numerals.md
@@ -645,16 +645,16 @@ var allRomanNumerals = RomanNumerals{
 
 // later..
 func ConvertToArabic(roman string) uint16 {
-    var arabic uint16 = 0
+	var arabic uint16 = 0
 
-    for _, numeral := range allRomanNumerals {
-        for strings.HasPrefix(roman, numeral.Symbol) {
-            arabic += numeral.Value
-            roman = strings.TrimPrefix(roman, numeral.Symbol)
-        }
-    }
+	for _, numeral := range allRomanNumerals {
+		for strings.HasPrefix(roman, numeral.Symbol) {
+			arabic += numeral.Value
+			roman = strings.TrimPrefix(roman, numeral.Symbol)
+		}
+	}
 
-    return arabic
+	return arabic
 }
 ```
 

--- a/roman-numerals/v10/roman_numerals.go
+++ b/roman-numerals/v10/roman_numerals.go
@@ -3,11 +3,17 @@ package v1
 import "strings"
 
 // ConvertToArabic converts a Roman Numeral to an Arabic number.
-func ConvertToArabic(roman string) (total int) {
-	for _, symbols := range windowedRoman(roman).Symbols() {
-		total += allRomanNumerals.ValueOf(symbols...)
+func ConvertToArabic(roman string) int {
+	arabic := 0
+
+	for _, numeral := range allRomanNumerals {
+		for strings.HasPrefix(roman, numeral.Symbol) {
+			arabic += numeral.Value
+			roman = strings.TrimPrefix(roman, numeral.Symbol)
+		}
 	}
-	return
+
+	return arabic
 }
 
 // ConvertToRoman converts an Arabic number to a Roman Numeral.
@@ -29,30 +35,7 @@ type romanNumeral struct {
 	Symbol string
 }
 
-type romanNumerals []romanNumeral
-
-func (r romanNumerals) ValueOf(symbols ...byte) int {
-	symbol := string(symbols)
-	for _, s := range r {
-		if s.Symbol == symbol {
-			return s.Value
-		}
-	}
-
-	return 0
-}
-
-func (r romanNumerals) Exists(symbols ...byte) bool {
-	symbol := string(symbols)
-	for _, s := range r {
-		if s.Symbol == symbol {
-			return true
-		}
-	}
-	return false
-}
-
-var allRomanNumerals = romanNumerals{
+var allRomanNumerals = []romanNumeral{
 	{1000, "M"},
 	{900, "CM"},
 	{500, "D"},
@@ -66,25 +49,4 @@ var allRomanNumerals = romanNumerals{
 	{5, "V"},
 	{4, "IV"},
 	{1, "I"},
-}
-
-type windowedRoman string
-
-func (w windowedRoman) Symbols() (symbols [][]byte) {
-	for i := 0; i < len(w); i++ {
-		symbol := w[i]
-		notAtEnd := i+1 < len(w)
-
-		if notAtEnd && isSubtractive(symbol) && allRomanNumerals.Exists(symbol, w[i+1]) {
-			symbols = append(symbols, []byte{symbol, w[i+1]})
-			i++
-		} else {
-			symbols = append(symbols, []byte{symbol})
-		}
-	}
-	return
-}
-
-func isSubtractive(symbol uint8) bool {
-	return symbol == 'I' || symbol == 'X' || symbol == 'C'
 }

--- a/roman-numerals/v11/roman_numerals.go
+++ b/roman-numerals/v11/roman_numerals.go
@@ -3,11 +3,17 @@ package v1
 import "strings"
 
 // ConvertToArabic converts a Roman Numeral to an Arabic number.
-func ConvertToArabic(roman string) (total uint16) {
-	for _, symbols := range windowedRoman(roman).Symbols() {
-		total += allRomanNumerals.ValueOf(symbols...)
+func ConvertToArabic(roman string) uint16 {
+	var arabic uint16 = 0
+
+	for _, numeral := range allRomanNumerals {
+		for strings.HasPrefix(roman, numeral.Symbol) {
+			arabic += numeral.Value
+			roman = strings.TrimPrefix(roman, numeral.Symbol)
+		}
 	}
-	return
+
+	return arabic
 }
 
 // ConvertToRoman converts an Arabic number to a Roman Numeral.
@@ -29,30 +35,7 @@ type romanNumeral struct {
 	Symbol string
 }
 
-type romanNumerals []romanNumeral
-
-func (r romanNumerals) ValueOf(symbols ...byte) uint16 {
-	symbol := string(symbols)
-	for _, s := range r {
-		if s.Symbol == symbol {
-			return s.Value
-		}
-	}
-
-	return 0
-}
-
-func (r romanNumerals) Exists(symbols ...byte) bool {
-	symbol := string(symbols)
-	for _, s := range r {
-		if s.Symbol == symbol {
-			return true
-		}
-	}
-	return false
-}
-
-var allRomanNumerals = romanNumerals{
+var allRomanNumerals = []romanNumeral{
 	{1000, "M"},
 	{900, "CM"},
 	{500, "D"},
@@ -66,25 +49,4 @@ var allRomanNumerals = romanNumerals{
 	{5, "V"},
 	{4, "IV"},
 	{1, "I"},
-}
-
-type windowedRoman string
-
-func (w windowedRoman) Symbols() (symbols [][]byte) {
-	for i := 0; i < len(w); i++ {
-		symbol := w[i]
-		notAtEnd := i+1 < len(w)
-
-		if notAtEnd && isSubtractive(symbol) && allRomanNumerals.Exists(symbol, w[i+1]) {
-			symbols = append(symbols, []byte{symbol, w[i+1]})
-			i++
-		} else {
-			symbols = append(symbols, []byte{symbol})
-		}
-	}
-	return
-}
-
-func isSubtractive(symbol uint8) bool {
-	return symbol == 'I' || symbol == 'X' || symbol == 'C'
 }


### PR DESCRIPTION
I think that your version of the conversion of roman numbers back to arabic numbers is too complicated, and distracts a bit from the main focus, the following property testing topic.

I've taken the `ConvertToRoman(int)` algorithm using it backwards, basically. I've updated the markdown accordingly and let my wife audit the text as her english is better than mine. But I deleted a lot of your previous tests and text of the complicated  algorithm you implemented. I hope you don't mind. There might now be a gap between the test for `ConvertToArabic("IV")` and the final version, but I don't know how to fill it. Maybe it's not even a problem, cause there were many test steps ahead of it already.