### PR TITLE
fix assertError func in maps chapter

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -222,6 +222,10 @@ t.Run("unknown word", func(t *testing.T) {
 func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
+	if got == nil {
+		t.Fatal("expected to get an error")
+	}
+
 	if got != want {
 		t.Errorf("got error %q want %q", got, want)
 	}

--- a/maps/v7/dictionary_test.go
+++ b/maps/v7/dictionary_test.go
@@ -88,6 +88,10 @@ func assertStrings(t testing.TB, got, want string) {
 func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
+	if got == nil {
+		t.Fatal("expected to get an error")
+	}
+
 	if got != want {
 		t.Errorf("got error %q want %q", got, want)
 	}


### PR DESCRIPTION
It's a small consistency fix, but making sure it is present reiterates the learning in the previous chapter.

Fixes this:
<img width="795" alt="image" src="https://github.com/quii/learn-go-with-tests/assets/9821727/7b4bf576-9ec3-47ae-9245-7c58d3a54bd2">
