### PR TITLE
roman-numberals.md: Don't use uint16 too early

### DIFF
--- a/roman-numerals.md
+++ b/roman-numerals.md
@@ -644,8 +644,8 @@ var allRomanNumerals = RomanNumerals{
 }
 
 // later..
-func ConvertToArabic(roman string) uint16 {
-	var arabic uint16 = 0
+func ConvertToArabic(roman string) int {
+	var arabic = 0
 
 	for _, numeral := range allRomanNumerals {
 		for strings.HasPrefix(roman, numeral.Symbol) {


### PR DESCRIPTION
It's only introduced later in the text.

The tests at the current stage all expect int.