### PR TITLE
Add missing ctx variable in the func main() in the "introduction to acceptance tests" chapter

### DIFF
--- a/intro-to-acceptance-tests.md
+++ b/intro-to-acceptance-tests.md
@@ -52,11 +52,13 @@ To that end, I wrote [https://pkg.go.dev/github.com/quii/go-graceful-shutdown](h
 
 ```go
 func main() {
-	httpServer := &http.Server{Addr: ":8080", Handler: http.HandlerFunc(acceptancetests.SlowHandler)}
+	var (
+    	ctx        = context.Background()
+    	httpServer = &http.Server{Addr: ":8080", Handler: http.HandlerFunc(acceptancetests.SlowHandler)}
+    	server     = gracefulshutdown.NewServer(httpServer)
+  	)
 
-	server := gracefulshutdown.NewServer(httpServer)
-
-	if err := server.ListenAndServe(); err != nil {
+	if err := server.ListenAndServe(ctx); err != nil {
 		// this will typically happen if our responses aren't written before the ctx deadline, not much can be done
 		log.Fatalf("uh oh, didnt shutdown gracefully, some responses may have been lost %v", err)
 	}
@@ -132,11 +134,13 @@ Let's take a look at the test program:
 
 ```go
 func main() {
-	httpServer := &http.Server{Addr: ":8080", Handler: http.HandlerFunc(acceptancetests.SlowHandler)}
+	var (
+    	ctx        = context.Background()
+    	httpServer = &http.Server{Addr: ":8080", Handler: http.HandlerFunc(acceptancetests.SlowHandler)}
+    	server     = gracefulshutdown.NewServer(httpServer)
+  	)
 
-	server := gracefulshutdown.NewServer(httpServer)
-
-	if err := server.ListenAndServe(); err != nil {
+	if err := server.ListenAndServe(ctx); err != nil {
 		// this will typically happen if our responses aren't written before the ctx deadline, not much can be done
 		log.Fatalf("uh oh, didnt shutdown gracefully, some responses may have been lost %v", err)
 	}


### PR DESCRIPTION
While I was reading the chapter ["Introduction to acceptance tests"](https://quii.gitbook.io/learn-go-with-tests/testing-fundamentals/intro-to-acceptance-tests#how-to-write-basic-acceptance-tests) with actual coding, I found the following missing part:

<img width="857" alt="Screenshot 2024-03-06 at 6 58 34 AM" src="https://github.com/quii/learn-go-with-tests/assets/89925675/24b37370-c4e3-47ca-8ec2-985a965820bf">

According to example code of [Graceful shutdown decorator package](https://pkg.go.dev/github.com/quii/go-graceful-shutdown#section-readme), I would like to suggest the same code example in the book as well:

```go
func main() {
  var (
    ctx        = context.Background()
    httpServer = &http.Server{Addr: ":8080", Handler: http.HandlerFunc(acceptancetests.SlowHandler)}
    server     = gracefulshutdown.NewServer(httpServer)
  )
  // code omitted
}
```