### PR TITLE
Correct syntax error in select.md

### DIFF
--- a/select.md
+++ b/select.md
@@ -269,7 +269,7 @@ func TestRacer(t *testing.T) {
 		fastURL := fastServer.URL
 
 		want := fastURL
-		got, err := Racer(slowURL, fastURL)
+		got, _ := Racer(slowURL, fastURL)
 
 		if got != want {
 			t.Errorf("got %q, want %q", got, want)


### PR DESCRIPTION
In the previous section, an error return was added to the `Racer()` function. In the text underneath this code block there is a note on [line 267](https://github.com/quii/learn-go-with-tests/compare/main...kevinlangmade:learn-go-with-tests:patch-1#diff-f3a62cc6403b42fe6683357a1b8dd83ef30d121c327702566b5d3dc4869a3f55L297) that says:

> Note that we've also handled the error return in our original text, we're using `_` for now to ensure the tests will run.

I think the error was not actually ignored with an underscore as you intended.