### PR TITLE
specify go version in Dockerfile

### DIFF
--- a/scaling-acceptance-tests.md
+++ b/scaling-acceptance-tests.md
@@ -366,7 +366,9 @@ Try and run the test.
 We need to create a Dockerfile for our program. Inside our `httpserver` folder, create a `Dockerfile` and add the following.
 
 ```dockerfile
-FROM golang:1.18-alpine
+# Make sure to specify the same Go version as the one in the go.mod file.
+# For example, golang:1.22.1-alpine.
+FROM golang:1.18-alpine 
 
 WORKDIR /app
 
@@ -968,6 +970,7 @@ If you run again, it should now _compile_ but not pass because we haven't create
 Create a new `Dockerfile` inside `cmd/grpcserver`.
 
 ```dockerfile
+# Make sure to specify the same Go version as the one in the go.mod file.
 FROM golang:1.18-alpine
 
 WORKDIR /app
@@ -1263,6 +1266,7 @@ You've probably noticed the two `Dockerfiles` are almost identical beyond the pa
 `Dockerfiles` can accept arguments to let us reuse them in different contexts, which sounds perfect. We can delete our 2 Dockerfiles and instead have one at the root of the project with the following
 
 ```dockerfile
+# Make sure to specify the same Go version as the one in the go.mod file.
 FROM golang:1.18-alpine
 
 WORKDIR /app


### PR DESCRIPTION
While reading [Scaling acceptance tests](https://quii.gitbook.io/learn-go-with-tests/testing-fundamentals/scaling-acceptance-tests), I tried building a docker image using the `Dockerfile` as the one in the book and failed to do so. 

Then I realized I was using Go version >= 1.22.0 on my machine and that was the main problem.

Although I don't think it would be a good idea to change the Go version used in the book(because everyone has her/his own favorite Go version), I think at least it would be good to mention it so that a reader could modify her/his own `Dockerfile` with the Go version installed on her/his machine.