### PR TITLE
in the hello example, reorder spanish and french and use variables in switch statement

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -462,10 +462,10 @@ func Hello(name string, language string) string {
 	prefix := englishHelloPrefix
 
 	switch language {
-	case "French":
-		prefix = frenchHelloPrefix
-	case "Spanish":
+	case spanish:
 		prefix = spanishHelloPrefix
+	case french:
+		prefix = frenchHelloPrefix
 	}
 
 	return prefix + name
@@ -481,8 +481,8 @@ You could argue that maybe our function is getting a little big. The simplest re
 ```go
 
 const (
-	french  = "French"
 	spanish = "Spanish"
+	french  = "French"
 
 	englishHelloPrefix = "Hello, "
 	spanishHelloPrefix = "Hola, "

--- a/hello-world/v7/hello.go
+++ b/hello-world/v7/hello.go
@@ -17,10 +17,10 @@ func Hello(name string, language string) string {
 	prefix := englishHelloPrefix
 
 	switch language {
-	case french:
-		prefix = frenchHelloPrefix
 	case spanish:
 		prefix = spanishHelloPrefix
+	case french:
+		prefix = frenchHelloPrefix
 	}
 
 	return prefix + name


### PR DESCRIPTION
it's a very minor improvement but I thought I might as well open a PR for it :slightly_smiling_face: 

basically this PR does two things in regards to the hello example:
 - reorder the places in which french is placed before spanish
   (to improve consistency, as currently spanish is sometimes before french and sometimes after)
 - in the language prefix switch use variables instead of string literals since those are already defined in the guide