### PR TITLE
fix the incorrect order of explanation of the `.Error()` method

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -155,7 +155,8 @@ func TestSearch(t *testing.T) {
 
 The way to handle this scenario in Go is to return a second argument which is an `Error` type.
 
-`Error`s can be converted to a string with the `.Error()` method, which we do when passing it to the assertion. We are also protecting `assertStrings` with `if` to ensure we don't call `.Error()` on `nil`.
+Notice that as we've seen in the [pointers and error section](./pointers-and-errors.md) here in order to asset the error message
+we first check that the error is not `nil` and then use `.Error()` method to get the string which we can then pass to the assertion.
 
 ## Try and run the test
 

--- a/pointers-and-errors.md
+++ b/pointers-and-errors.md
@@ -455,6 +455,7 @@ Update our helper for a `string` to compare against.
 ```go
 assertError := func(t testing.TB, got error, want string) {
 	t.Helper()
+
 	if got == nil {
 		t.Fatal("didn't get an error but wanted one")
 	}
@@ -464,6 +465,8 @@ assertError := func(t testing.TB, got error, want string) {
 	}
 }
 ```
+
+As you can see `Error`s can be converted to a string with the `.Error()` method, which we do in order to compare it with the string we want. We are also making sure that the error is not `nil` to ensure we don't call `.Error()` on `nil`.
 
 And then update the caller
 


### PR DESCRIPTION
The `.Error()` method is used in the pointers and errors section without an explanation, and is then explained in the maps section (which comes after the pointers and errors one).

The changes here are reordering this so that readers get the explanation in the pointers and errors section.