### PR TITLE
fix incorrect incorrect local links to the dependency injection section

### DIFF
--- a/html-templates.md
+++ b/html-templates.md
@@ -667,7 +667,7 @@ We'll leave this as an exercise for you, the reader. You should be able to find 
 
 **Note**. Be careful not to worry too much about explicitly testing how a 3rd party library behaves in unit tests. 
 
-Writing tests against code you don't control is wasteful and adds maintenance overhead. Sometimes you may wish to use [dependency injection](/dependency-injection.md) to control a dependency and mock its behaviour for a test. 
+Writing tests against code you don't control is wasteful and adds maintenance overhead. Sometimes you may wish to use [dependency injection](./dependency-injection.md) to control a dependency and mock its behaviour for a test.
 
 In this case though, I view converting the markdown into HTML as implementation detail of rendering, and our approval tests should give us enough confidence.
 

--- a/os-exec.md
+++ b/os-exec.md
@@ -15,7 +15,7 @@
 A few things
 
 - When something is difficult to test, it's often due to the separation of concerns not being quite right
-- Don't add "test modes" into your code, instead use [Dependency Injection](/dependency-injection.md) so that you can model your dependencies and separate concerns.
+- Don't add "test modes" into your code, instead use [Dependency Injection](./dependency-injection.md) so that you can model your dependencies and separate concerns.
 
 I have taken the liberty of guessing what the code might look like
 


### PR DESCRIPTION
Fix the dependency injection links pointing to `/dependency-injection.md` instead of `./dependency-injection.md`

Although this absolute links do work in the gitbook site they don't work in the EPUB and PDF versions