### PR TITLE
fix: fix inconsistent definition of `assertError` function in maps section

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -363,16 +363,9 @@ func TestAdd(t *testing.T) {
 		assertDefinition(t, dictionary, word, definition)
 	})
 }
-
-func assertError(t testing.TB, got, want error) {
-	t.Helper()
-	if got != want {
-		t.Errorf("got %q want %q", got, want)
-	}
-}
 ```
 
-For this test, we modified `Add` to return an error, which we are validating against a new error variable, `ErrWordExists`. We also modified the previous test to check for a `nil` error, as well as the `assertError` function.
+For this test, we modified `Add` to return an error, which we are validating against a new error variable, `ErrWordExists`. We also modified the previous test to check for a `nil` error.
 
 ## Try to run test
 

--- a/maps/v1/dictionary_test.go
+++ b/maps/v1/dictionary_test.go
@@ -15,6 +15,6 @@ func assertStrings(t testing.TB, got, want string) {
 	t.Helper()
 
 	if got != want {
-		t.Errorf("got %q want %q", got, want)
+		t.Errorf("got error %q want %q", got, want)
 	}
 }


### PR DESCRIPTION
The `assertError` in the maps section is introduced here:
https://github.com/quii/learn-go-with-tests/blob/7c5b39c9c0182b53c9e2c0a892f52252a3592d62/maps.md?plain=1#L222-L228

as you can see with the failure error being `got error "X" want "Y"`

This does not match the v1 go code: https://github.com/quii/learn-go-with-tests/blob/7c5b39c9c0182b53c9e2c0a892f52252a3592d62/maps/v1/dictionary_test.go#L18

Further down the section the `assertError` helper is refactored:
https://github.com/quii/learn-go-with-tests/blob/7c5b39c9c0182b53c9e2c0a892f52252a3592d62/maps.md?plain=1#L367-L375

to update the failure error to `got "X" want "Y"` (without `error`)

This does not really make much sense and is also not reflected anywhere in the section's go code (see: [v2](https://github.com/quii/learn-go-with-tests/blob/7c5b39c9c0182b53c9e2c0a892f52252a3592d62/maps/v2/dictionary_test.go#L36), [v3](https://github.com/quii/learn-go-with-tests/blob/main/maps/v3/dictionary_test.go#L46), ..., [v7](https://github.com/quii/learn-go-with-tests/blob/7c5b39c9c0182b53c9e2c0a892f52252a3592d62/maps/v7/dictionary_test.go#L92))

So this PR is amending the erroneous v1 go code and removing the unnecessary/incorrect refactoring