### PR TITLE
explain what the `%p` placeholder prints

### DIFF
--- a/pointers-and-errors.md
+++ b/pointers-and-errors.md
@@ -138,8 +138,8 @@ func (w Wallet) Deposit(amount int) {
 }
 ```
 
-The `\n` escape character prints a new line after outputting the memory address.
-We get the pointer (memory address) of something by placing an `&` character at the beginning of the symbol.
+The `%p` placeholder prints memory addresses in base 16 notation with leading `0x`s and the `\n` escape character prints a new line.
+Note that we get the pointer (memory address) of something by placing an `&` character at the beginning of the symbol.
 
 Now re-run the test
 


### PR DESCRIPTION
closes #711

:point_up: hopefully this should be enough to close #711 given the fact that #616 has already been merged