### PR TITLE
Add example of calling generic constructor with type that cannot be inferred

### DIFF
--- a/generics.md
+++ b/generics.md
@@ -513,7 +513,7 @@ func (s *Stack[Apple]) Pop() (Apple, bool)
 
 Now that we have done this refactoring, we can safely remove the string stack test because we don't need to prove the same logic over and over.
 
-Note that so far in the examples of calling generic functions, we have not needed to specify the generic types. For example, to call `AssertEqual[T]`, we do not need to specify what the type `T` is since it can be inferred from the arguments. In cases where the generic types cannot be inferred, you need specify the types when calling the function. The syntax is the same as when defining the function, i.e. you specify the types inside square brackets before the arguments.
+Note that so far in the examples of calling generic functions, we have not needed to specify the generic types. For example, to call `AssertEqual[T]`, we do not need to specify what the type `T` is since it can be inferred from the arguments. In cases where the generic types cannot be inferred, you need to specify the types when calling the function. The syntax is the same as when defining the function, i.e. you specify the types inside square brackets before the arguments.
 
 For a concrete example, consider making a constructor for `Stack[T]`.
 ```go

--- a/generics/generics_test.go
+++ b/generics/generics_test.go
@@ -18,7 +18,7 @@ func TestAssertFunctions(t *testing.T) {
 
 func TestStack(t *testing.T) {
 	t.Run("integer stack", func(t *testing.T) {
-		myStackOfInts := new(Stack[int])
+		myStackOfInts := NewStack[int]()
 
 		// check stack is empty
 		AssertTrue(t, myStackOfInts.IsEmpty())

--- a/generics/stack.go
+++ b/generics/stack.go
@@ -4,6 +4,10 @@ type Stack[T any] struct {
 	values []T
 }
 
+func NewStack[T any]() *Stack[T] {
+	return new(Stack[T])
+}
+
 func (s *Stack[T]) Push(value T) {
 	s.values = append(s.values, value)
 }


### PR DESCRIPTION
For issue #770

As an example of how to specify types when calling a function with a generic type that cannot be inferred, added a constructor for `Stack[T]` to Generics chapter. Added to text and code.