### PR TITLE
fix: typos in the chapter about maps

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -155,7 +155,7 @@ func TestSearch(t *testing.T) {
 
 The way to handle this scenario in Go is to return a second argument which is an `Error` type.
 
-Notice that as we've seen in the [pointers and error section](./pointers-and-errors.md) here in order to asset the error message
+Notice that as we've seen in the [pointers and error section](./pointers-and-errors.md) here in order to assert the error message
 we first check that the error is not `nil` and then use `.Error()` method to get the string which we can then pass to the assertion.
 
 ## Try and run the test
@@ -595,7 +595,7 @@ func TestDelete(t *testing.T) {
 	dictionary.Delete(word)
 
 	_, err := dictionary.Search(word)
-	assertError(t, word, ErrNotFound)
+	assertError(t, err, ErrNotFound)
 }
 ```
 
@@ -620,7 +620,7 @@ func (d Dictionary) Delete(word string) {
 After we add this, the test tells us we are not deleting the word.
 
 ```
-dictionary_test.go:78: Expected 'test' to be deleted
+dictionary_test.go:78: got error '%!q(<nil>)' want 'could not find the word you were looking for'
 ```
 
 ## Write enough code to make it pass


### PR DESCRIPTION
Fixing a few typos I've found in the `Maps` chapter.