### PR TITLE
Add note on potential go benchmark optimisations 

### DIFF
--- a/iteration.md
+++ b/iteration.md
@@ -123,7 +123,7 @@ PASS
 
 What `136 ns/op` means is our function takes on average 136 nanoseconds to run \(on my computer\). Which is pretty ok! To test this it ran it 10000000 times.
 
-_NOTE_ by default Benchmarks are run sequentially.
+**Note:** By default Benchmarks are run sequentially.
 
 ## Practice exercises
 

--- a/iteration.md
+++ b/iteration.md
@@ -125,7 +125,7 @@ What `136 ns/op` means is our function takes on average 136 nanoseconds to run \
 
 **Note:** By default benchmarks are run sequentially.
 
-**Note:** Go can sometimes optimize benchmarks and render them inaccurate. You should look at your benchmarks and see if the values make sense. If benchmarks are being optimized, you can follow strategies laid out in this **[blog post](https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go)**
+**Note:** Sometimes, Go can optimize your benchmarks in a way that makes them inaccurate, such as eliminating the function being benchmarked. Check your benchmarks to see if the values make sense. If they seem overly optimized, you can follow the strategies in this **[blog post](https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go)**
 
 ## Practice exercises
 

--- a/iteration.md
+++ b/iteration.md
@@ -123,7 +123,9 @@ PASS
 
 What `136 ns/op` means is our function takes on average 136 nanoseconds to run \(on my computer\). Which is pretty ok! To test this it ran it 10000000 times.
 
-**Note:** By default Benchmarks are run sequentially.
+**Note:** By default benchmarks are run sequentially.
+
+**Note:** Go can sometimes optimize benchmarks and render them inaccurate. You should look at your benchmarks and see if the values make sense. If benchmarks are being optimized, you can follow strategies laid out in this **[blog post](https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go)**
 
 ## Practice exercises
 

--- a/iteration.md
+++ b/iteration.md
@@ -125,7 +125,7 @@ What `136 ns/op` means is our function takes on average 136 nanoseconds to run \
 
 **Note:** By default benchmarks are run sequentially.
 
-**Note:** Sometimes, Go can optimize your benchmarks in a way that makes them inaccurate, such as eliminating the function being benchmarked. Check your benchmarks to see if the values make sense. If they seem overly optimized, you can follow the strategies in this **[blog post](https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go)**
+**Note:** Sometimes, Go can optimize your benchmarks in a way that makes them inaccurate, such as eliminating the function being benchmarked. Check your benchmarks to see if the values make sense. If they seem overly optimized, you can follow the strategies in this **[blog post](https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go)**.
 
 ## Practice exercises
 


### PR DESCRIPTION
To address issue #694, I added a note warning that Go can sometimes optimize functions being benchmarked, leading to inaccurate results. From research this issue seems to be rare, but it is  probably still a good idea to warn users about it. There are several related issues in the Go repository, and people are looking for guidance from the Go team. I believe a warning is sufficient for now, as the benchmarks in the lesson follow the same practices as those in the Go documentation and most other codebases. However, this may need to be revisited in the future if best practices change. I linked a blog post from [Dave Cheney](https://dave.cheney.net/) in the warning so that people could read more and see how to address this issue if it comes up for them. 
