### PR TITLE
Pass err instead of word to assertError function

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -595,7 +595,7 @@ func TestDelete(t *testing.T) {
 	dictionary.Delete(word)
 
 	_, err := dictionary.Search(word)
-	assertError(t, word, ErrNotFound)
+	assertError(t, err, ErrNotFound)
 }
 ```
 


### PR DESCRIPTION
Fix a typo while following the `maps` chapter.
![CleanShot 2024-07-05 at 15 53 11@2x](https://github.com/quii/learn-go-with-tests/assets/38986298/fb7cd32f-7984-4727-9349-6e3696fe346b)
