### PR TITLE
Expanding on maps delete to make it more consistent with add and update

### DIFF
--- a/maps/v6/dictionary.go
+++ b/maps/v6/dictionary.go
@@ -7,8 +7,8 @@ const (
 	// ErrWordExists means you are trying to add a word that is already known
 	ErrWordExists = DictionaryErr("cannot add word because it already exists")
 
-	// ErrWordDoesNotExist occurs when trying to update a word not in the dictionary
-	ErrWordDoesNotExist = DictionaryErr("cannot update word because it does not exist")
+	// ErrWordDoesNotExist occurs when trying to perform an operation on a word not in the dictionary
+	ErrWordDoesNotExist = DictionaryErr("cannot perform operation on word because it does not exist")
 )
 
 // DictionaryErr are errors that can happen when interacting with the dictionary.

--- a/maps/v7/dictionary.go
+++ b/maps/v7/dictionary.go
@@ -7,8 +7,8 @@ const (
 	// ErrWordExists means you are trying to add a word that is already known
 	ErrWordExists = DictionaryErr("cannot add word because it already exists")
 
-	// ErrWordDoesNotExist occurs when trying to update a word not in the dictionary
-	ErrWordDoesNotExist = DictionaryErr("cannot update word because it does not exist")
+	// ErrWordDoesNotExist occurs when trying to perform an operation on a word not in the dictionary
+	ErrWordDoesNotExist = DictionaryErr("cannot perform operation on word because it does not exist")
 )
 
 // DictionaryErr are errors that can happen when interacting with the dictionary.
@@ -64,6 +64,17 @@ func (d Dictionary) Update(word, definition string) error {
 }
 
 // Delete removes a word from the dictionary.
-func (d Dictionary) Delete(word string) {
-	delete(d, word)
+func (d Dictionary) Delete(word string) error {
+	_, err := d.Search(word)
+	switch err {
+	case ErrNotFound:
+		return ErrWordDoesNotExist
+	case nil:
+		delete(d, word)
+	default:
+		return err
+
+	}
+
+	return nil
 }

--- a/maps/v7/dictionary_test.go
+++ b/maps/v7/dictionary_test.go
@@ -68,13 +68,27 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	word := "test"
-	dictionary := Dictionary{word: "test definition"}
+	t.Run("existing word", func(t *testing.T) {
+		word := "test"
+		dictionary := Dictionary{word: "test definition"}
 
-	dictionary.Delete(word)
+		err := dictionary.Delete(word)
 
-	_, err := dictionary.Search(word)
-	assertError(t, err, ErrNotFound)
+		assertError(t, err, nil)
+
+		_, err = dictionary.Search(word)
+
+		assertError(t, err, ErrNotFound)
+	})
+
+	t.Run("non-existing word", func(t *testing.T) {
+		word := "test"
+		dictionary := Dictionary{}
+
+		err := dictionary.Delete(word)
+
+		assertError(t, err, ErrWordDoesNotExist)
+	})
 }
 
 func assertStrings(t testing.TB, got, want string) {


### PR DESCRIPTION
In this PR I expanded on the `Delete` method in the maps chapter to be consistent with other CRUD operations in the case that the word being deleted does not exist. The same `Update` switch structure is used to capture errors with a minor change `ErrWordDoesNotExist` to make it applicable to both update and delete operations. 

