### PR TITLE
fix: "assertError" wrong parameter  sent  in the markdown file

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -595,7 +595,7 @@ func TestDelete(t *testing.T) {
 	dictionary.Delete(word)
 
 	_, err := dictionary.Search(word)
-	assertError(t, word, ErrNotFound)
+	assertError(t, err, ErrNotFound)
 }
 ```
 


### PR DESCRIPTION
```Go
func TestDelete(t *testing.T) {
	word := "test"
	dictionary := Dictionary{word: "test definition"}

	dictionary.Delete(word)

	_, err := dictionary.Search(word)
	assertError(t, word, ErrNotFound)
}
```

in this above test in the markdown in the assertError call the  paramters should be (t, err, ErrNotFound)
instead of the `err`  `word` has been passed resulting in wrong type sent to the assertError.