### PR TITLE
Bump GitHub actions to their latest versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,12 +13,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: 1.22
 
     - name: Build
       run: ./build.sh
@@ -29,7 +29,7 @@ jobs:
     - name: Get release
       id: get_release
       if: github.event_name == 'release' && github.event.action == 'published'
-      uses: bruceadams/get-release@v1.2.3
+      uses: bruceadams/get-release@v1.3.2
       env:
         GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions, thus avoiding deprecation warnings as seen e.g. [here](https://github.com/quii/learn-go-with-tests/actions/runs/10013103638).