### PR TITLE
fix: Correct exposed port in testcontainers-go config

### DIFF
--- a/scaling-acceptance-tests.md
+++ b/scaling-acceptance-tests.md
@@ -334,8 +334,13 @@ func TestGreeterServer(t *testing.T) {
 			// set to false if you want less spam, but this is helpful if you're having troubles
 			PrintBuildLog: true,
 		},
-		ExposedPorts: []string{"8080"},
+		ExposedPorts: []string{"8080/tcp"},
 		WaitingFor:   wait.ForHTTP("/").WithPort("8080"),
+        HostConfigModifier: func(hc *container.HostConfig) {
+			hc.PortBindings = map[nat.Port][]nat.PortBinding{
+				"8080/tcp": {{HostPort: "8080/tcp"}},
+			}
+		},
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,

--- a/scaling-acceptance-tests.md
+++ b/scaling-acceptance-tests.md
@@ -334,7 +334,7 @@ func TestGreeterServer(t *testing.T) {
 			// set to false if you want less spam, but this is helpful if you're having troubles
 			PrintBuildLog: true,
 		},
-		ExposedPorts: []string{"8080:8080"},
+		ExposedPorts: []string{"8080"},
 		WaitingFor:   wait.ForHTTP("/").WithPort("8080"),
 	}
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{


### PR DESCRIPTION
As per title. The current config is not correct and results in the following error:

```
greeter_server_test.go:36: Did not expect an error but got:
        failed to start container: all exposed ports, [8080:8080], were not mapped in 5s: port 8080:8080 is not mapped yet
```