### PR TITLE
fix: mocking code exemple

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -373,6 +373,7 @@ func Countdown(out io.Writer, sleeper Sleeper) {
 		fmt.Fprintln(out, i)
 	}
 
+	sleeper.Sleep()
 	fmt.Fprint(out, finalWord)
 }
 ```


### PR DESCRIPTION
One execution of `sleeper.Sleep()` was missing in the code example.