### PR TITLE
fix: add missing whitespace

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -365,7 +365,7 @@ func SumAll(numbersToSum ...[]int) []int {
 Lots of new things to learn!
 
 There's a new way to create a slice. `make` allows you to create a slice with
-a starting capacity of the `len` of the `numbersToSum` we need to work through.The length of a slice is the number of elements it holds `len(mySlice)`, while the capacity is the number of elements it can hold in the underlying array `cap(mySlice)`, e.g., `make([]int, 0, 5)` creates a slice with length 0 and capacity 5.
+a starting capacity of the `len` of the `numbersToSum` we need to work through. The length of a slice is the number of elements it holds `len(mySlice)`, while the capacity is the number of elements it can hold in the underlying array `cap(mySlice)`, e.g., `make([]int, 0, 5)` creates a slice with length 0 and capacity 5.
 
 You can index slices like arrays with `mySlice[N]` to get the value out or
 assign it a new value with `=`


### PR DESCRIPTION
Whitespace has been missing between the sentences since a6c085db36f137cc37b6bba08f908aa8c4e7f14d .