### PR TITLE
Fix Typos in Context

### DIFF
--- a/context.md
+++ b/context.md
@@ -144,7 +144,7 @@ func Server(store Store) http.HandlerFunc {
 }
 ```
 
-This makes this test pass but it doesn't feel good does it! We surely shouldn't be cancelling `Store` before we fetch on _every request_.
+This makes this test pass but it doesn't feel good does it! We surely shouldn't be cancelling `Cancel()` before we fetch on _every request_.
 
 By being disciplined it highlighted a flaw in our tests, this is a good thing!
 

--- a/context.md
+++ b/context.md
@@ -71,7 +71,7 @@ type Store interface {
 }
 ```
 
-We will need to adjust our spy so it takes some time to return `data` and a way of knowing it has been told to cancel. We'll also rename it to `SpyStore` as we are now observing the way it is called. It'll have to add `Cancel` as a method to implement the `Store` interface.
+We will need to adjust our spy so it takes some time to return `data` and a way of knowing it has been told to cancel. It'll have to add `Cancel` as a method to implement the `Store` interface.
 
 ```go
 type SpyStore struct {


### PR DESCRIPTION
One sentence mentions renaming a struct for clarity, but the struct has had the same name throughout the page.

Another sentence references the `Store` interface where it should be referencing the `Cancel()` method of the interface.