### PR TITLE
fix: Update go to 1.22 in CI tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.22
 
     - name: Build
       run: ./build.sh


### PR DESCRIPTION
In my previous PR I bumped the version of go to 1.22. I forgot to do that in the CI, sorry about that. This PR should fix that.