### PR TITLE
Update math.md, simplifying secondsToRadiant return operation

### DIFF
--- a/math.md
+++ b/math.md
@@ -494,7 +494,7 @@ So instead of
 
 we can write
 
-	π / (30 / numberOfSeconds)
+	π * (numberOfSeconds / 30)
 
 which is equivalent.
 
@@ -502,7 +502,7 @@ In Go:
 
 ```go
 func secondsInRadians(t time.Time) float64 {
-	return (math.Pi / (30 / (float64(t.Second()))))
+	return math.Pi * (float64(t.Second()) / 30)
 }
 ```
 


### PR DESCRIPTION
I want to propose this change to simplify the lecture of the math chapter.

By simplifying the radiant division in the `secondsToRadiant` and use the parameter as numerator instead of denominator we avoid handling a 0 case type.

Benefits:
- We can short the chapter removing the zero division error explanation.
- By dividing the func parameter Is easier to read and we avoid the imprecise floating points
- If func param is 0 then the return value will be 0 instead of an error.

I hope this helps to simplify the code and the lecture.
Thanks for this great course