### PR TITLE
Use errors.Is for error comparison in assertError helper

### DIFF
--- a/maps/v2/dictionary_test.go
+++ b/maps/v2/dictionary_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -32,7 +33,7 @@ func assertStrings(t testing.TB, got, want string) {
 func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
-	if got != want {
+	if !errors.Is(got, want) {
 		t.Errorf("got error %q want %q", got, want)
 	}
 }

--- a/maps/v3/dictionary_test.go
+++ b/maps/v3/dictionary_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -42,7 +43,7 @@ func assertStrings(t testing.TB, got, want string) {
 func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
-	if got != want {
+	if !errors.Is(got, want) {
 		t.Errorf("got error %q want %q", got, want)
 	}
 }

--- a/maps/v4/dictionary_test.go
+++ b/maps/v4/dictionary_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -55,7 +56,7 @@ func assertStrings(t testing.TB, got, want string) {
 func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
-	if got != want {
+	if !errors.Is(got, want) {
 		t.Errorf("got error %q want %q", got, want)
 	}
 }

--- a/maps/v5/dictionary_test.go
+++ b/maps/v5/dictionary_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -66,7 +67,7 @@ func assertStrings(t testing.TB, got, want string) {
 func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
-	if got != want {
+	if !errors.Is(got, want) {
 		t.Errorf("got error %q want %q", got, want)
 	}
 }

--- a/maps/v6/dictionary_test.go
+++ b/maps/v6/dictionary_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -78,7 +79,7 @@ func assertStrings(t testing.TB, got, want string) {
 func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
-	if got != want {
+	if !errors.Is(got, want) {
 		t.Errorf("got error %q want %q", got, want)
 	}
 }

--- a/maps/v7/dictionary_test.go
+++ b/maps/v7/dictionary_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -102,7 +103,7 @@ func assertStrings(t testing.TB, got, want string) {
 func assertError(t testing.TB, got, want error) {
 	t.Helper()
 
-	if got != want {
+	if !errors.Is(got, want) {
 		t.Errorf("got error %q want %q", got, want)
 	}
 }


### PR DESCRIPTION
# What problem are you trying to solve?
The current `assertError` helper function in the Maps chapter uses direct error comparison (`!=`) which doesn't handle wrapped errors correctly. This could teach readers a pattern that might not work in real-world scenarios where error wrapping is common.

# What changes are you making?
Updated the `assertError` helper function to use `errors.Is` instead of direct comparison. This better reflects modern Go error handling practices and will work correctly with wrapped errors.

# Example
Before:
```
if got != want {
    t.Errorf("got error %q want %q", got, want)
}
```
After:
```
if !errors.Is(got, want) {
    t.Errorf("got error %q want %q", got, want)
}
```

Additional context

errors.Is was introduced in Go 1.13 and is now the recommended way to compare errors. This change helps teach more robust error handling patterns.
If this change is approved, I will create a corresponding update to the README file to explain why `errors.Is` is preferred over direct comparison and provide examples of when it's particularly useful (such as with wrapped errors).
