### PR TITLE
[Bugfix] Templating: Fix Broken Render Function

### DIFF
--- a/html-templates.md
+++ b/html-templates.md
@@ -196,7 +196,7 @@ New lines! Who cares? Well, our test does, because it's matching on an exact str
 
 ```go
 func Render(w io.Writer, p Post) error {
-	_, err := fmt.Fprintf(w, "<h1>%s</h1><p>%s</p>", p.Title, p.Description)
+	_, err := fmt.Fprintf(w, "<h1>%s</h1>\n<p>%s</p>\n", p.Title, p.Description)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In the following section [Write enough code to make it pass](https://quii.gitbook.io/learn-go-with-tests/go-fundamentals/html-templates#write-enough-code-to-make-it-pass-1), we need to add new-line delimiters `\n`, so that the expectation in the test _it converts a single post into HTML_ is satisfied.

The specs for that section will fail if the `\n` is not added.