### PR TITLE
update: fix typo in time.md

### DIFF
--- a/time.md
+++ b/time.md
@@ -473,7 +473,7 @@ func NewCLI(store PlayerStore, in io.Reader, out io.Writer, alerter BlindAlerter
 
 Now the _other_ tests will fail to compile because they don't have an `io.Writer` being passed into `NewCLI`.
 
-Add `dummyStdout` for the other tests.
+Add `dummyStdOut` for the other tests.
 
 The new test should fail like so
 


### PR DESCRIPTION
This PR relates to this issue:
https://github.com/quii/learn-go-with-tests/issues/853
