### PR TITLE
fix: clarify note about reverting Countdown function

### DIFF
--- a/mocking.md
+++ b/mocking.md
@@ -379,7 +379,20 @@ func Countdown(out io.Writer, sleeper Sleeper) {
 
 If you run your tests they should still be passing even though the implementation is wrong.
 
-Let's use spying again with a new test to check the order of operations is correct.
+> Note: Don't forget to revert the `Countdown` function to its correct implementation afterwards to avoid failing tests in subsequent sections. Restore it back to:
+
+```go
+func Countdown(out io.Writer, sleeper Sleeper) {
+	for i := countdownStart; i > 0; i-- {
+		fmt.Fprintln(out, i)
+		sleeper.Sleep()
+	}
+
+	fmt.Fprint(out, finalWord)
+}
+```
+
+Now, let's use spying again with a new test to check the order of operations is correct.
 
 We have two different dependencies and we want to record all of their operations into one list. So we'll create _one spy for them both_.
 


### PR DESCRIPTION
While following the mocking chapter of the book, I ran into a test failure after modifying the `Countdown()` function as suggested. The issue was that there wasn't an explicit instruction to revert the code snippet to its original, working version afterwards.

This small detail can easily confuse Go beginners who are following along line by line. Although the source code serves as a reference, adding a clear note in the book helps avoid unnecessary confusion and improves the learning experience.

This PR adds that clarification as a note just after the line:

> if you run your tests they should still be passing even though the implementation is wrong.

@quii 