### PR TITLE
feat: Update benchmarking to use b.Loop() and bump go specification to 1.24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23
+        go-version: 1.24
 
     - name: Build
       run: ./build.sh

--- a/blogrenderer/renderer_test.go
+++ b/blogrenderer/renderer_test.go
@@ -63,8 +63,7 @@ func BenchmarkRender(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		postRenderer.Render(io.Discard, aPost)
 	}
 }

--- a/concurrency.md
+++ b/concurrency.md
@@ -92,8 +92,8 @@ func BenchmarkCheckWebsites(b *testing.B) {
 	for i := 0; i < len(urls); i++ {
 		urls[i] = "a url"
 	}
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		CheckWebsites(slowStubWebsiteChecker, urls)
 	}
 }
@@ -102,8 +102,7 @@ func BenchmarkCheckWebsites(b *testing.B) {
 The benchmark tests `CheckWebsites` using a slice of one hundred urls and uses
 a new fake implementation of `WebsiteChecker`. `slowStubWebsiteChecker` is
 deliberately slow. It uses `time.Sleep` to wait exactly twenty milliseconds and
-then it returns true. We use `b.ResetTimer()` in this test to reset the time of our
-test before it actually runs
+then it returns true.
 
 
 When we run the benchmark using `go test -bench=.` (or if you're in Windows Powershell `go test -bench="."`):

--- a/concurrency/v1/check_websites_benchmark_test.go
+++ b/concurrency/v1/check_websites_benchmark_test.go
@@ -16,7 +16,7 @@ func BenchmarkCheckWebsites(b *testing.B) {
 		urls[i] = "a url"
 	}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		CheckWebsites(slowStubWebsiteChecker, urls)
 	}
 }

--- a/concurrency/v2/check_websites_benchmark_test.go
+++ b/concurrency/v2/check_websites_benchmark_test.go
@@ -16,7 +16,7 @@ func BenchmarkCheckWebsites(b *testing.B) {
 		urls[i] = "a url"
 	}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		CheckWebsites(slowStubWebsiteChecker, urls)
 	}
 }

--- a/concurrency/v3/check_websites_benchmark_test.go
+++ b/concurrency/v3/check_websites_benchmark_test.go
@@ -16,7 +16,7 @@ func BenchmarkCheckWebsites(b *testing.B) {
 		urls[i] = "a url"
 	}
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		CheckWebsites(slowStubWebsiteChecker, urls)
 	}
 }

--- a/for/vx/repeat_test.go
+++ b/for/vx/repeat_test.go
@@ -12,7 +12,7 @@ func TestRepeat(t *testing.T) {
 }
 
 func BenchmarkRepeat(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Repeat("a")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/quii/learn-go-with-tests
 
-go 1.23
+go 1.24
 
 require (
 	github.com/approvals/go-approval-tests v0.0.0-20211008131110-0c40b30e0000

--- a/html-templates.md
+++ b/html-templates.md
@@ -557,8 +557,7 @@ func BenchmarkRender(b *testing.B) {
 		}
 	)
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		blogrenderer.Render(io.Discard, aPost)
 	}
 }
@@ -646,8 +645,7 @@ func BenchmarkRender(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		postRenderer.Render(io.Discard, aPost)
 	}
 }

--- a/iteration.md
+++ b/iteration.md
@@ -97,7 +97,7 @@ Writing [benchmarks](https://golang.org/pkg/testing/#hdr-Benchmarks) in Go is an
 
 ```go
 func BenchmarkRepeat(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		Repeat("a")
 	}
 }
@@ -105,11 +105,11 @@ func BenchmarkRepeat(b *testing.B) {
 
 You'll see the code is very similar to a test.
 
-The `testing.B` gives you access to the cryptically named `b.N`.
+The `testing.B` gives you access to the loop function. `Loop()` returns true as long as the benchmark should continue running. 
 
-When the benchmark code is executed, it runs `b.N` times and measures how long it takes.
+When the benchmark code is executed, it measures how long it takes. After `Loop()` returns false, `b.N` contains the total number of iterations that ran.
 
-The amount of times the code is run shouldn't matter to you, the framework will determine what is a "good" value for that to let you have some decent results.
+The number of times the code is run shouldn't matter to you, the framework will determine what is a "good" value for that to let you have some decent results.
 
 To run the benchmarks do `go test -bench=.` (or if you're in Windows Powershell `go test -bench="."`)
 
@@ -125,7 +125,17 @@ What `136 ns/op` means is our function takes on average 136 nanoseconds to run \
 
 **Note:** By default benchmarks are run sequentially.
 
-**Note:** Sometimes, Go can optimize your benchmarks in a way that makes them inaccurate, such as eliminating the function being benchmarked. Check your benchmarks to see if the values make sense. If they seem overly optimized, you can follow the strategies in this **[blog post](https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go)**.
+Only the body of the loop is timed; it automatically excludes setup and cleanup code from benchmark timing. A typical benchmark is structured like:
+
+```go
+func Benchmark(b *testing.B) {
+	//... setup ...
+	for b.Loop() {
+		//... code to measure ...
+	}
+	//... cleanup ...
+}
+```
 
 Strings in Go are immutable, meaning every concatenation, such as in our `Repeat` function, involves copying memory to accommodate the new string. This impacts performance, particularly during heavy string concatenation.
 


### PR DESCRIPTION
This updates the benchmarking to take advantage of the new standard 'testing.B.Loop'. This results in simpler and more predictable benchmarking. For instance, `b.ResetTimer()` is no longer required. I also believe the notice

> **Note:** Sometimes, Go can optimize your benchmarks in a way that makes them inaccurate, such as eliminating the function being benchmarked. Check your benchmarks to see if the values make sense. If they seem overly optimized, you can follow the strategies in this **[blog post](https://dave.cheney.net/2013/06/30/how-to-write-benchmarks-in-go)**.

also no longer applies as 

> The compiler never optimizes away calls to functions within the body of a "for b.Loop() { ... }" loop.

See:
- https://go.dev/blog/testing-b-loop
- https://pkg.go.dev/testing#hdr-Benchmarks
- https://pkg.go.dev/testing#B.Loop

This request also bumps the go specification to 1.24 which is needed for this.