### PR TITLE
Complete French translation : adding links to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [中文](https://studygolang.gitbook.io/learn-go-with-tests)
 - [Português](https://larien.gitbook.io/aprenda-go-com-testes/)
 - [日本語](https://andmorefine.gitbook.io/learn-go-with-tests/)
+- [Français](https://goosegeesejeez.gitbook.io/apprendre-go-par-les-tests)
 - [한국어](https://miryang.gitbook.io/learn-go-with-tests/)
 - [Türkçe](https://halilkocaoz.gitbook.io/go-programlama-dilini-ogren/)
 - [فارسی](https://go-yaad-begir.gitbook.io/go-ba-test/)

--- a/gb-readme.md
+++ b/gb-readme.md
@@ -26,6 +26,7 @@ Translations:
 - [中文](https://studygolang.gitbook.io/learn-go-with-tests)
 - [Português](https://larien.gitbook.io/aprenda-go-com-testes/)
 - [日本語](https://andmorefine.gitbook.io/learn-go-with-tests/)
+- [Français](https://goosegeesejeez.gitbook.io/apprendre-go-par-les-tests)
 - [한국어](https://miryang.gitbook.io/learn-go-with-tests/)
 - [Türkçe](https://halilkocaoz.gitbook.io/go-programlama-dilini-ogren/)
 


### PR DESCRIPTION
I put this translation above the incomplete ones in the list. If there's anything wrong with it, I'm open to discussion.

**Gitbook** : [Apprendre Go par les Tests](https://goosegeesejeez.gitbook.io/apprendre-go-par-les-tests)

**Repo** : [learn-go-with-tests-fr](https://github.com/GooseGeeseJeez/learn-go-with-tests-fr) - branch `traduction-français`