### PR TITLE
fix: recreate parser when loop benchmark

### DIFF
--- a/blogrenderer/renderer_test.go
+++ b/blogrenderer/renderer_test.go
@@ -57,13 +57,13 @@ func BenchmarkRender(b *testing.B) {
 		}
 	)
 
-	postRenderer, err := blogrenderer.NewPostRenderer()
-
-	if err != nil {
-		b.Fatal(err)
-	}
-
 	for b.Loop() {
+		postRenderer, err := blogrenderer.NewPostRenderer()
+
+		if err != nil {
+			b.Fatal(err)
+		}
+
 		postRenderer.Render(io.Discard, aPost)
 	}
 }


### PR DESCRIPTION
## Problem
Parser instances are not reusable in benchmark loops, causing panic when attempting to reuse the same Parser for multiple Parse() calls.

<img width="724" height="49" alt="Screenshot 2025-08-06 at 14 30 45" src="https://github.com/user-attachments/assets/66d3abc9-d4b9-4889-acd5-e1b600998f8b" />

## Solution  
Recreate a new Parser instance for each benchmark iteration instead of reusing the same instance.
