### PR TITLE
Replace b.Loop() with correct benchmark loop syntax in Go

### DIFF
--- a/blogrenderer/renderer_test.go
+++ b/blogrenderer/renderer_test.go
@@ -63,7 +63,7 @@ func BenchmarkRender(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		postRenderer.Render(io.Discard, aPost)
 	}
 }

--- a/concurrency.md
+++ b/concurrency.md
@@ -93,7 +93,7 @@ func BenchmarkCheckWebsites(b *testing.B) {
 		urls[i] = "a url"
 	}
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		CheckWebsites(slowStubWebsiteChecker, urls)
 	}
 }

--- a/concurrency/v1/check_websites_benchmark_test.go
+++ b/concurrency/v1/check_websites_benchmark_test.go
@@ -16,7 +16,7 @@ func BenchmarkCheckWebsites(b *testing.B) {
 		urls[i] = "a url"
 	}
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		CheckWebsites(slowStubWebsiteChecker, urls)
 	}
 }

--- a/concurrency/v2/check_websites_benchmark_test.go
+++ b/concurrency/v2/check_websites_benchmark_test.go
@@ -16,7 +16,7 @@ func BenchmarkCheckWebsites(b *testing.B) {
 		urls[i] = "a url"
 	}
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		CheckWebsites(slowStubWebsiteChecker, urls)
 	}
 }

--- a/concurrency/v3/check_websites_benchmark_test.go
+++ b/concurrency/v3/check_websites_benchmark_test.go
@@ -16,7 +16,7 @@ func BenchmarkCheckWebsites(b *testing.B) {
 		urls[i] = "a url"
 	}
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		CheckWebsites(slowStubWebsiteChecker, urls)
 	}
 }

--- a/for/vx/repeat_test.go
+++ b/for/vx/repeat_test.go
@@ -12,7 +12,7 @@ func TestRepeat(t *testing.T) {
 }
 
 func BenchmarkRepeat(b *testing.B) {
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		Repeat("a")
 	}
 }

--- a/html-templates.md
+++ b/html-templates.md
@@ -557,7 +557,7 @@ func BenchmarkRender(b *testing.B) {
 		}
 	)
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		blogrenderer.Render(io.Discard, aPost)
 	}
 }
@@ -645,7 +645,7 @@ func BenchmarkRender(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		postRenderer.Render(io.Discard, aPost)
 	}
 }

--- a/iteration.md
+++ b/iteration.md
@@ -97,7 +97,7 @@ Writing [benchmarks](https://golang.org/pkg/testing/#hdr-Benchmarks) in Go is an
 
 ```go
 func BenchmarkRepeat(b *testing.B) {
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		Repeat("a")
 	}
 }
@@ -130,7 +130,7 @@ Only the body of the loop is timed; it automatically excludes setup and cleanup 
 ```go
 func Benchmark(b *testing.B) {
 	//... setup ...
-	for b.Loop() {
+	for i := 0; i < b.N; i++ {
 		//... code to measure ...
 	}
 	//... cleanup ...


### PR DESCRIPTION
Replace b.Loop()   with for i:= 0; i< b.N; i++  syntax in 
- blogrenderer/renderer_test.go
- concurrency/v1/check_websites_benchmark_test.go
- concurrency/v2/check_websites_benchmark_test.go  
- concurrency/v3/check_websites_benchmark_test.go
- for/vx/repeat_test.go
- concurrency.md
- html-templates.md (2 instances)
- iteration.md (2 instances)

Verified with `./build.sh` - all tests pass

Fixes #869