### PR TITLE
Remove (probably) outdated sentence

### DIFF
--- a/select.md
+++ b/select.md
@@ -315,8 +315,6 @@ func Racer(a, b string) (winner string, error error) {
 
 Change the signature of `Racer` to return the winner and an `error`. Return `nil` for our happy cases.
 
-The compiler will complain about your _first test_ only looking for one value so change that line to `got, err := Racer(slowURL, fastURL)`, knowing that we should check we _don't_ get an error in our happy scenario.
-
 If you run it now after 11 seconds it will fail.
 
 ```


### PR DESCRIPTION
This paragraph is probably a leftover from a previous version of this chapter.

The text says:

> The compiler will complain about your _first test_ only looking for one value (...)

However, right above the code of the first test is already gracefully handling the second value being returned. This fact is even mentioned in the text!

Hopefully this screenshot can make it clear:

<img width="644" height="1038" alt="image" src="https://github.com/user-attachments/assets/5574d196-a8a4-4c46-8b21-e2c9fbb9f2e5" />
