### PR TITLE
Use strings.Builder for Post body scanning

### DIFF
--- a/reading-files.md
+++ b/reading-files.md
@@ -769,11 +769,11 @@ func newPost(postBody io.Reader) (Post, error) {
 
 	scanner.Scan() // ignore a line
 
-	buf := bytes.Buffer{}
+	var b strings.Builder
 	for scanner.Scan() {
-		fmt.Fprintln(&buf, scanner.Text())
+		fmt.Fprintln(&b, scanner.Text())
 	}
-	body := strings.TrimSuffix(buf.String(), "\n")
+	body := strings.TrimSuffix(b.String(), "\n")
 
 	return Post{
 		Title:       title,
@@ -811,11 +811,11 @@ func newPost(postBody io.Reader) (Post, error) {
 
 func readBody(scanner *bufio.Scanner) string {
 	scanner.Scan() // ignore a line
-	buf := bytes.Buffer{}
+	var b strings.Builder
 	for scanner.Scan() {
-		fmt.Fprintln(&buf, scanner.Text())
+		fmt.Fprintln(&b, scanner.Text())
 	}
-	return strings.TrimSuffix(buf.String(), "\n")
+	return strings.TrimSuffix(b.String(), "\n")
 }
 ```
 

--- a/reading-files/post.go
+++ b/reading-files/post.go
@@ -2,7 +2,6 @@ package blogposts
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"strings"
@@ -40,9 +39,9 @@ func newPost(postBody io.Reader) (Post, error) {
 
 func readBody(scanner *bufio.Scanner) string {
 	scanner.Scan() // ignore a line
-	buf := bytes.Buffer{}
+	var b strings.Builder
 	for scanner.Scan() {
-		fmt.Fprintln(&buf, scanner.Text())
+		fmt.Fprintln(&b, scanner.Text())
 	}
-	return strings.TrimSuffix(buf.String(), "\n")
+	return strings.TrimSuffix(b.String(), "\n")
 }


### PR DESCRIPTION
Since `scanner.Text()` returns a string, in my mind seems like `strings.Builder` might be a more expected fit for string building.
Not sure if there is another reason to keep bytes.Buffer. If there is feel free to enlighten me of the reason behind it, thanks!