### PR TITLE
fix(docs): update link to actual documentation

### DIFF
--- a/hello-world.md
+++ b/hello-world.md
@@ -150,7 +150,7 @@ General:
 
 Go's second tool for viewing documentation is the pkgsite command, which powers Go's official package viewing website.  You can install pkgsite with `go install golang.org/x/pkgsite/cmd/pkgsite@latest`, then run it with `pkgsite -open .`.  Go's install command will download the source files from that repository and build them into an executable binary.  For a default installation of Go, that executable will be in `$HOME/go/bin` for Linux and macOS, and `%USERPROFILE%\go\bin` for Windows.  If you have not already added those paths to your $PATH var, you might want to do so to make running go-installed commands easier.
 
-The vast majority of the standard library has excellent documentation with examples. Navigating to [http://localhost:8080/testing](http://localhost:8080/testing) would be worthwhile to see what's available to you.
+The vast majority of the standard library has excellent documentation with examples. Navigating to [https://pkg.go.dev/testing](https://pkg.go.dev/testing) would be worthwhile to see what's available to you.
 
 
 ### Hello, YOU


### PR DESCRIPTION
This [section](https://quii.gitbook.io/learn-go-with-tests/go-fundamentals/hello-world#gos-documentation) points to documentation hosted locally. Linking the golang dev pkg docs would be better.  