### PR TITLE
fix: changed all leftover reflect.DeepEqual in Array and Slices chapter to slices.Equal

### DIFF
--- a/arrays-and-slices.md
+++ b/arrays-and-slices.md
@@ -384,7 +384,7 @@ func TestSumAllTails(t *testing.T) {
 	got := SumAllTails([]int{1, 2}, []int{0, 9})
 	want := []int{2, 9}
 
-	if !reflect.DeepEqual(got, want) {
+	if !slices.Equal(got, want) {
 		t.Errorf("got %v want %v", got, want)
 	}
 }
@@ -437,7 +437,7 @@ func TestSumAllTails(t *testing.T) {
 		got := SumAllTails([]int{1, 2}, []int{0, 9})
 		want := []int{2, 9}
 
-		if !reflect.DeepEqual(got, want) {
+		if !slices.Equal(got, want) {
 			t.Errorf("got %v want %v", got, want)
 		}
 	})
@@ -446,7 +446,7 @@ func TestSumAllTails(t *testing.T) {
 		got := SumAllTails([]int{}, []int{3, 4, 5})
 		want := []int{0, 9}
 
-		if !reflect.DeepEqual(got, want) {
+		if !slices.Equal(got, want) {
 			t.Errorf("got %v want %v", got, want)
 		}
 	})
@@ -493,7 +493,7 @@ func TestSumAllTails(t *testing.T) {
 
 	checkSums := func(t testing.TB, got, want []int) {
 		t.Helper()
-		if !reflect.DeepEqual(got, want) {
+		if !slices.Equal(got, want) {
 			t.Errorf("got %v want %v", got, want)
 		}
 	}
@@ -540,7 +540,7 @@ We have covered
   * How to slice, slices!
 * `len` to get the length of an array or slice
 * Test coverage tool
-* `reflect.DeepEqual` and why it's useful but can reduce the type-safety of your code
+* `slices.Equal` and why it is needed instead of regular equality operators
 
 We've used slices and arrays with integers but they work with any other type
 too, including arrays/slices themselves. So you can declare a variable of


### PR DESCRIPTION
Any tests that use reflect.DeepEqual are changed to use the newer slices.Equal which the updated version of the chapter introduces and uses.

The summary is changed to give a short callout to slices.Equal instead of reflect.DeepEqual.

All changes are made only in arrays-and-slices.md where some usages of the old function were leftover.

Closes #907.