### PR TITLE
docs: fix stale README link, broken anchor, and dummyStdOut typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If you have such a question raise it as an issue on github and I'll try and find
 ## Contributing
 
 * _This project is work in progress_ If you would like to contribute, please do get in touch.
-* Read [contributing.md](https://github.com/quii/learn-go-with-tests/tree/842f4f24d1f1c20ba3bb23cbc376c7ca6f7ca79a/contributing.md) for guidelines
+* Read [contributing.md](contributing.md) for guidelines
 * Any ideas? Create an issue
 
 ## Background

--- a/integers.md
+++ b/integers.md
@@ -69,7 +69,7 @@ Now run the tests, and we should be happy that the test is correctly reporting w
 
 `adder_test.go:10: expected '4' but got '0'`
 
-If you have noticed we learnt about _named return value_ in the [last](hello-world.md#one...last...refactor?) section but aren't using the same here. It should generally be used when the meaning of the result isn't clear from context, in our case it's pretty much clear that `Add` function will add the parameters. You can refer [this](https://go.dev/wiki/CodeReviewComments#named-result-parameters) wiki for more details.
+If you have noticed we learnt about _named return value_ in the [last](hello-world.md#onelastrefactor) section but aren't using the same here. It should generally be used when the meaning of the result isn't clear from context, in our case it's pretty much clear that `Add` function will add the parameters. You can refer [this](https://go.dev/wiki/CodeReviewComments#named-result-parameters) wiki for more details.
 
 ## Write enough code to make it pass
 

--- a/time.md
+++ b/time.md
@@ -470,7 +470,7 @@ func NewCLI(store PlayerStore, in io.Reader, out io.Writer, alerter BlindAlerter
 
 Now the _other_ tests will fail to compile because they don't have an `io.Writer` being passed into `NewCLI`.
 
-Add `dummyStdout` for the other tests.
+Add `dummyStdOut` for the other tests.
 
 The new test should fail like so
 


### PR DESCRIPTION
A few small documentation fixes I noticed while reading through the book.

**`README.md`** — the link to `contributing.md` was pinned to commit [`842f4f2`](https://github.com/quii/learn-go-with-tests/commit/842f4f24d1f1c20ba3bb23cbc376c7ca6f7ca79a) ("lets try this"), which is nine commits out of date. Changed it to a relative link so it always tracks `main`.

**`integers.md`** — the link back to the "One...last...refactor?" section of `hello-world.md` points at an anchor GitHub's slugifier doesn't actually produce (it strips the dots and the question mark). Updated it to `#onelastrefactor`, which is the form GitHub generates and matches the convention used elsewhere in the book (e.g. `iteration.md#benchmarking`).

**`time.md`** — the prose refers to `dummyStdout`, but the variable is declared as `dummyStdOut` on line 433 and used that way throughout `time/v2` and `time/v3`. Closes #853.