### PR TITLE
Update Denise Yu link in gb-readme.md - She doesn't have a X/Twitter account anymore

### DIFF
--- a/gb-readme.md
+++ b/gb-readme.md
@@ -2,7 +2,7 @@
 
 ![](.gitbook/assets/red-green-blue-gophers-smaller.png)
 
-[Art by Denise](https://twitter.com/deniseyu21)
+[Art by Denise](https://deniseyu.io/)
 
 ## Support me
 


### PR DESCRIPTION
Apparently Denise Yu doesn't have a X/Twitter account anymore or changed her username and I could not find the new one, even after visiting her site and other social media profiles.

So I think it's good to have her site's link instead. People can know about her from there: [https://deniseyu.io/](https://deniseyu.io/)